### PR TITLE
fix(get) Json empty list is null, not []

### DIFF
--- a/client/downloads.go
+++ b/client/downloads.go
@@ -22,6 +22,10 @@ func (c *client) ListDownloadTasks(ctx context.Context) (result []types.Download
 		return nil, fmt.Errorf("failed to GET downloads/ endpoint: %w", err)
 	}
 
+	if response.Result == nil {
+		return
+	}
+
 	if err = c.fromGenericResponse(response, &result); err != nil {
 		return nil, fmt.Errorf("failed to get download tasks from generic response: %w", err)
 	}

--- a/client/filesystem.go
+++ b/client/filesystem.go
@@ -76,6 +76,10 @@ func (c *client) ListFileSystemTasks(ctx context.Context) (task []types.FileSyst
 		return task, fmt.Errorf("failed to GET fs/tasks/ endpoint: %w", err)
 	}
 
+	if response.Result == nil {
+		return
+	}
+
 	if err = c.fromGenericResponse(response, &task); err != nil {
 		return task, fmt.Errorf("failed to get a list of filesystem tasks from a generic response: %w", err)
 	}


### PR DESCRIPTION
When listing download and filesystem tasks and there is no, the freebox does not return the field `result` and then unmarshalling a nil value fails.
This PR aims to detect it and return an empty list before trying to decode the result.