### PR TITLE
fix(404) Returns task/path not found when detected

### DIFF
--- a/client/filesystem.go
+++ b/client/filesystem.go
@@ -90,6 +90,13 @@ func (c *client) ListFileSystemTasks(ctx context.Context) (task []types.FileSyst
 func (c *client) GetFileSystemTask(ctx context.Context, identifier int64) (task types.FileSystemTask, err error) {
 	response, err := c.get(ctx, fmt.Sprintf("fs/tasks/%d", identifier), c.withSession(ctx))
 	if err != nil {
+		if response != nil {
+			// The invalid_id code is returned when the task ID is not found
+			if response.ErrorCode == codeTaskNotFound || response.ErrorCode == string(types.FileTaskErrorInvalidID) {
+				return task, ErrTaskNotFound
+			}
+		}
+
 		return task, fmt.Errorf("failed to GET fs/tasks/%d endpoint: %w", identifier, err)
 	}
 

--- a/client/virtual_machines_disks.go
+++ b/client/virtual_machines_disks.go
@@ -18,7 +18,11 @@ func (c *client) GetVirtualDiskInfo(ctx context.Context, path string) (result ty
 		DiskPath: types.Base64Path(path),
 	}, c.withSession(ctx))
 	if err != nil {
-		return result, fmt.Errorf("failed to GET vm/disk/info endpoint: %w", err)
+		if response != nil && response.ErrorCode == types.DiskErrorNotFound {
+			return result, ErrPathNotFound
+		}
+
+		return result, fmt.Errorf("failed to POST vm/disk/info/ endpoint: %w", err)
 	}
 
 	if err = c.fromGenericResponse(response, &result); err != nil {
@@ -53,6 +57,10 @@ func (c *client) CreateVirtualDisk(ctx context.Context, payload types.VirtualDis
 func (c *client) GetVirtualDiskTask(ctx context.Context, identifier int64) (result types.VirtualMachineDiskTask, err error) {
 	response, err := c.get(ctx, fmt.Sprintf("vm/disk/task/%d", identifier), c.withSession(ctx))
 	if err != nil {
+		if response != nil && response.ErrorCode == types.DiskTaskErrorNotFound {
+			return result, ErrTaskNotFound
+		}
+
 		return result, fmt.Errorf("failed to GET vm/disk/task/%d endpoint: %w", identifier, err)
 	}
 


### PR DESCRIPTION
The PR aims to return `ErrTaskNotFound` or `ErrPathNotFound` when possible.

Please review #17 first.