### PR TITLE
feat(api) Introduce APIError

### DIFF
--- a/client/authentication_test.go
+++ b/client/authentication_test.go
@@ -489,7 +489,7 @@ var _ = Describe("authentication", func() {
 				})
 				It("should return an error", func() {
 					Expect(*returnedErr).ToNot(BeNil())
-					Expect((*returnedErr).Error()).To(MatchRegexp("failed with error code 'bad_request': some error"))
+					Expect((*returnedErr).Error()).To(MatchRegexp(`failed with error code "bad_request": some error`))
 				})
 			})
 			Context("because the returned body is an invalid JSON object", func() {
@@ -568,7 +568,7 @@ var _ = Describe("authentication", func() {
 				})
 				It("should return an error", func() {
 					Expect(*returnedErr).ToNot(BeNil())
-					Expect((*returnedErr).Error()).To(MatchRegexp("failed with error code 'invalid_token': Erreur d'authentification de l'application"))
+					Expect((*returnedErr).Error()).To(MatchRegexp(`failed with error code "invalid_token": Erreur d'authentification de l'application`))
 				})
 			})
 			Context("because the returned body is an invalid JSON object", func() {

--- a/client/common.go
+++ b/client/common.go
@@ -126,7 +126,10 @@ func (c *client) fromHTTPResponse(httpResponse *http.Response) (*genericResponse
 	}
 
 	if !response.Success {
-		return response, fmt.Errorf("failed with error code '%s': %s", response.ErrorCode, response.Message)
+		return response, &APIError{
+			Code: response.ErrorCode,
+			Message: response.Message,
+		}
 	}
 
 	return response, nil
@@ -162,4 +165,24 @@ func (c *client) withSession(ctx context.Context) func(req *http.Request) error 
 
 		return nil
 	}
+}
+
+// APIError represents a structured Freebox API error.
+type APIError struct {
+	Code    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("task failed with code %q: %s", e.Code, e.Message)
+	}
+
+	return fmt.Sprintf("task failed with code %q", e.Code)
+}
+
+func (e *APIError) Is(target error) bool {
+	t, ok := target.(*APIError)
+
+	return ok && t.Code == e.Code
 }

--- a/client/common.go
+++ b/client/common.go
@@ -175,10 +175,10 @@ type APIError struct {
 
 func (e *APIError) Error() string {
 	if e.Message != "" {
-		return fmt.Sprintf("task failed with code %q: %s", e.Code, e.Message)
+		return fmt.Sprintf("failed with error code %q: %s", e.Code, e.Message)
 	}
 
-	return fmt.Sprintf("task failed with code %q", e.Code)
+	return fmt.Sprintf("failed with error code %q", e.Code)
 }
 
 func (e *APIError) Is(target error) bool {

--- a/client/common_test.go
+++ b/client/common_test.go
@@ -23,13 +23,13 @@ var _ = Describe("APIError", func() {
 			})
 
 			It("should return a string without code", func() {
-				Expect(err.Error()).To(Equal(`task failed with code "": message`))
+				Expect(err.Error()).To(Equal(`failed with error code "": message`))
 			})
 		})
 
 		Context("when Message is empty", func() {
 			It("should return a string without code and message", func() {
-				Expect(err.Error()).To(Equal(`task failed with code ""`))
+				Expect(err.Error()).To(Equal(`failed with error code ""`))
 			})
 		})
 	})
@@ -41,7 +41,7 @@ var _ = Describe("APIError", func() {
 
 		Context("when Message is empty", func() {
 			It("should return a string without message", func() {
-				Expect(err.Error()).To(Equal(`task failed with code "code"`))
+				Expect(err.Error()).To(Equal(`failed with error code "code"`))
 			})
 		})
 
@@ -51,7 +51,7 @@ var _ = Describe("APIError", func() {
 			})
 
 			It("should return a string without message", func() {
-				Expect(err.Error()).To(Equal(`task failed with code "code": message`))
+				Expect(err.Error()).To(Equal(`failed with error code "code": message`))
 			})
 
 			Describe("errors.IS", func() {

--- a/client/common_test.go
+++ b/client/common_test.go
@@ -1,0 +1,99 @@
+package client_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nikolalohinski/free-go/client"
+)
+
+var _ = Describe("APIError", func() {
+	var err *client.APIError
+
+	BeforeEach(func() {
+		err = &client.APIError{}
+	})
+
+	Context("when Code is empty", func() {
+		Context("when Message is not empty", func() {
+			BeforeEach(func() {
+				err.Message = "message"
+			})
+
+			It("should return a string without code", func() {
+				Expect(err.Error()).To(Equal(`task failed with code "": message`))
+			})
+		})
+
+		Context("when Message is empty", func() {
+			It("should return a string without code and message", func() {
+				Expect(err.Error()).To(Equal(`task failed with code ""`))
+			})
+		})
+	})
+
+	Context("when Code is not empty", func() {
+		BeforeEach(func() {
+			err.Code = "code"
+		})
+
+		Context("when Message is empty", func() {
+			It("should return a string without message", func() {
+				Expect(err.Error()).To(Equal(`task failed with code "code"`))
+			})
+		})
+
+		Context("when Message is not empty", func() {
+			BeforeEach(func() {
+				err.Message = "message"
+			})
+
+			It("should return a string without message", func() {
+				Expect(err.Error()).To(Equal(`task failed with code "code": message`))
+			})
+
+			Describe("errors.IS", func() {
+				var target *client.APIError
+
+				BeforeEach(func() {
+					target = &client.APIError{}
+				})
+
+				Context("when target has the same code", func() {
+					BeforeEach(func() {
+						target.Code = err.Code
+					})
+
+					It("should return true for APIError", func() {
+						Expect(errors.Is(err, target)).To(BeTrue())
+					})
+				})
+
+				Context("when target has a different code", func() {
+					BeforeEach(func() {
+						target.Code = "not_" + err.Code
+					})
+
+					It("should return false for APIError", func() {
+						Expect(errors.Is(err, target)).To(BeFalse())
+					})
+				})
+			})
+
+			Describe("APIError.As", func() {
+				var target *client.APIError
+
+				BeforeEach(func() {
+					target = &client.APIError{}
+				})
+
+				It("should return true for APIError", func() {
+					Expect(errors.As(err, &target)).To(BeTrue())
+					Expect(target.Code).To(Equal(err.Code))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
Introduce new `APIError` type so it becomes easily testable with [`errors.Is`](https://pkg.go.dev/errors#Is).