### PR TITLE
Implements DHCP static lease calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ At the time of this writing, generating credentials can only be done via the Fre
 - [ ] [DHCP](https://dev.freebox.fr/sdk/os/dhcp/#dhcp) : `/dhcp/*`
   - [ ] Get the current DHCP configuration
   - [ ] Update the current DHCP configuration
-  - [ ] List the DHCP static leases
-  - [ ] Get a given DHCP static lease
-  - [ ] Update DHCP static lease
-  - [ ] Delete a DHCP static lease
-  - [ ] Add a DHCP static lease
+  - [x] List the DHCP static leases
+  - [x] Get a given DHCP static lease
+  - [x] Update DHCP static lease
+  - [x] Delete a DHCP static lease
+  - [x] Add a DHCP static lease
   - [ ] Get the list of DHCP dynamic leases
 - [x] [Port forwarding](https://dev.freebox.fr/sdk/os/nat/#port-forwarding): `/fw/redir/*`
   - [x] Getting the list of port forwarding

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ At the time of this writing, generating credentials can only be done via the Fre
   - [ ] Wake on LAN
   - [ ] Get the current Lan configuration
   - [ ] Update the current Lan configuration
+- [ ] [DHCP](https://dev.freebox.fr/sdk/os/dhcp/#dhcp) : `/dhcp/*`
+  - [ ] Get the current DHCP configuration
+  - [ ] Update the current DHCP configuration
+  - [ ] List the DHCP static leases
+  - [ ] Get a given DHCP static lease
+  - [ ] Update DHCP static lease
+  - [ ] Delete a DHCP static lease
+  - [ ] Add a DHCP static lease
+  - [ ] Get the list of DHCP dynamic leases
 - [x] [Port forwarding](https://dev.freebox.fr/sdk/os/nat/#port-forwarding): `/fw/redir/*`
   - [x] Getting the list of port forwarding
   - [x] Getting a specific port forwarding

--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,12 @@ type Client interface {
 	CreatePortForwardingRule(ctx context.Context, payload types.PortForwardingRulePayload) (types.PortForwardingRule, error)
 	UpdatePortForwardingRule(ctx context.Context, identifier int64, payload types.PortForwardingRulePayload) (types.PortForwardingRule, error)
 	DeletePortForwardingRule(ctx context.Context, identifier int64) error
+	// dhcp
+	ListDHCPStaticLease(context.Context) ([]types.DHCPStaticLeaseInfo, error)
+	GetDHCPStaticLease(ctx context.Context, identifier string) (types.DHCPStaticLeaseInfo, error)
+	UpdateDHCPStaticLease(ctx context.Context, identifier string, payload types.DHCPStaticLeasePayload) (types.LanInterfaceHost, error)
+	CreateDHCPStaticLease(ctx context.Context, payload types.DHCPStaticLeasePayload) (types.LanInterfaceHost, error)
+	DeleteDHCPStaticLease(ctx context.Context, identifier string) error
 	// lan browser
 	ListLanInterfaceInfo(context.Context) ([]types.LanInfo, error)
 	GetLanInterface(ctx context.Context, name string) (result []types.LanInterfaceHost, err error)

--- a/client/dhcp_static.go
+++ b/client/dhcp_static.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+func (c *client) ListDHCPStaticLease(ctx context.Context) (result []types.DHCPStaticLeaseInfo, err error) {
+	response, err := c.get(ctx, "dhcp/static_lease/", c.withSession(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to GET dhcp/static_lease/ endpoint: %w", err)
+	}
+
+	if response.Result == nil {
+		return
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to list dhcp static lease from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) GetDHCPStaticLease(ctx context.Context, identifier string) (result types.DHCPStaticLeaseInfo, err error) {
+	response, err := c.get(ctx, fmt.Sprintf("dhcp/static_lease/%s", identifier), c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to GET dhcp/static_lease/%s endpoint: %w", identifier, err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to get dhcp static lease from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) UpdateDHCPStaticLease(ctx context.Context, identifier string, payload types.DHCPStaticLeasePayload) (result types.LanInterfaceHost, err error) {
+	response, err := c.put(ctx, fmt.Sprintf("dhcp/static_lease/%s", identifier), c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to PUT dhcp/static_lease/%s endpoint: %w", identifier, err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to update dhcp static lease from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) CreateDHCPStaticLease(ctx context.Context, payload types.DHCPStaticLeasePayload) (result types.LanInterfaceHost, err error) {
+	response, err := c.post(ctx, "dhcp/static_lease/", payload, c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to POST dhcp/static_lease/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to create dhcp static lease from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) DeleteDHCPStaticLease(ctx context.Context, identifier string) error {
+	_, err := c.delete(ctx, fmt.Sprintf("dhcp/static_lease/%s", identifier), c.withSession(ctx))
+	if err != nil {
+		return fmt.Errorf("failed to DELETE dhcp/static_lease/%s endpoint: %w", identifier, err)
+	}
+
+	return nil
+}

--- a/client/dhcp_static_test.go
+++ b/client/dhcp_static_test.go
@@ -1,0 +1,538 @@
+package client_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/onsi/gomega/gstruct"
+
+	"github.com/nikolalohinski/free-go/client"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("DHCPStatic", func() {
+	var (
+		freeboxClient client.Client
+
+		server   *ghttp.Server
+		endpoint = new(string)
+
+		sessionToken = new(string)
+
+		returnedErr = new(error)
+	)
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		DeferCleanup(server.Close)
+		*endpoint = server.Addr()
+
+		freeboxClient = Must(client.New(*endpoint, version)).
+			WithAppID(appID).
+			WithPrivateToken(privateToken)
+
+		*sessionToken = setupLoginFlow(server)
+	})
+
+	Context("ListDHCPStaticLease", func() {
+		const (
+			IPAddress  = "192.168.1.10"
+			MACAddress = "00:11:22:33:44:55"
+		)
+		returnedDHCPStatjcLeases := new([]types.DHCPStaticLeaseInfo)
+
+		JustBeforeEach(func(ctx SpecContext) {
+			*returnedDHCPStatjcLeases, *returnedErr = freeboxClient.ListDHCPStaticLease(ctx)
+		})
+
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/%s/dhcp/static_lease/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool                        `json:"success"`
+							Result  []types.DHCPStaticLeaseInfo `json:"result"`
+						}{
+							Success: true,
+							Result: []types.DHCPStaticLeaseInfo{
+								{
+									ID:       "identifier",
+									IP:       IPAddress,
+									Mac:      MACAddress,
+									Comment:  CurrentSpecReport().FullText(),
+									Hostname: "test-hostname",
+									Host: types.LanInterfaceHost{
+										L2Ident: types.L2Ident{
+											ID:   MACAddress,
+											Type: types.MacAddress,
+										},
+										Active:     true,
+										Persistent: true,
+										Names: []types.HostName{
+											{
+												Name:   "test",
+												Source: "dhcp",
+											},
+										},
+										VendorName:        "vendor",
+										Type:              "workstation",
+										Interface:         "pub",
+										ID:                "ether-7e:ec:37:cd:5b:6a",
+										LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+										PrimaryNameManual: true,
+										L3Connectivities: []types.L3Connectivity{
+											{
+												Address:           IPAddress,
+												Active:            true,
+												Reachable:         true,
+												LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+												Type:              "ipv4",
+												LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+											},
+										},
+										DefaultName:   "testing",
+										FirstActivity: types.Timestamp{Time: time.Unix(1682578724, 0)},
+										Reachable:     true,
+										LastActivity:  types.Timestamp{Time: time.Unix(1682578724, 0)},
+										PrimaryName:   "testing",
+									},
+								},
+							},
+						}),
+					),
+				)
+			})
+
+			It("should return the list of DHCP static leases", func() {
+				Expect(*returnedErr).ToNot(HaveOccurred())
+				Expect(*returnedDHCPStatjcLeases).To(ConsistOf(
+					gstruct.MatchAllFields(gstruct.Fields{
+						"ID":       Equal("identifier"),
+						"IP":       Equal(IPAddress),
+						"Mac":      Equal(MACAddress),
+						"Comment":  Equal(CurrentSpecReport().FullText()),
+						"Hostname": Equal("test-hostname"),
+						"Host": gstruct.MatchAllFields(gstruct.Fields{
+							"L2Ident": gstruct.MatchAllFields(gstruct.Fields{
+								"ID":   Equal(MACAddress),
+								"Type": Equal(types.MacAddress),
+							}),
+							"Active":     BeTrue(),
+							"Persistent": BeTrue(),
+							"Names": ConsistOf(gstruct.MatchAllFields(gstruct.Fields{
+								"Name":   Equal("test"),
+								"Source": Equal("dhcp"),
+							})),
+							"VendorName": Equal("vendor"),
+							"Type":       Equal("workstation"),
+							"Interface":  Equal("pub"),
+							"ID":         Equal("ether-7e:ec:37:cd:5b:6a"),
+							"LastTimeReachable": gstruct.MatchAllFields(gstruct.Fields{
+								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+							}),
+							"PrimaryNameManual": BeTrue(),
+							"L3Connectivities": ConsistOf(gstruct.MatchAllFields(gstruct.Fields{
+								"Address":   Equal(IPAddress),
+								"Active":    BeTrue(),
+								"Reachable": BeTrue(),
+								"LastActivity": gstruct.MatchAllFields(gstruct.Fields{
+									"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+								}),
+								"Type": Equal("ipv4"),
+								"LastTimeReachable": gstruct.MatchAllFields(gstruct.Fields{
+									"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+								}),
+							})),
+							"DefaultName": Equal("testing"),
+							"FirstActivity": gstruct.MatchAllFields(gstruct.Fields{
+								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+							}),
+							"Reachable": BeTrue(),
+							"LastActivity": gstruct.MatchAllFields(gstruct.Fields{
+								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+							}),
+							"PrimaryName": Equal("testing"),
+						}),
+					})),
+				)
+			})
+		})
+
+		Context("when the server returns an error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/%s/dhcp/static_lease/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool `json:"success"`
+						}{
+							Success: false,
+						}),
+					),
+				)
+			})
+
+			It("should return an error", func() {
+				Expect(*returnedErr).To(HaveOccurred())
+			})
+		})
+
+		Context("when the server returns an empty result", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/%s/dhcp/static_lease/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool `json:"success"`
+						}{
+							Success: true,
+						}),
+					),
+				)
+			})
+
+			It("should return an empty list", func() {
+				Expect(*returnedErr).ToNot(HaveOccurred())
+				Expect(*returnedDHCPStatjcLeases).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("GetDHCPStaticLease", func() {
+		const (
+			IPAddress  = "192.168.1.11"
+			MACAddress = "00:11:22:33:44:56"
+		)
+
+		returnedDHCPStaticLease := new(types.DHCPStaticLeaseInfo)
+
+		JustBeforeEach(func(ctx SpecContext) {
+			*returnedDHCPStaticLease, *returnedErr = freeboxClient.GetDHCPStaticLease(ctx, MACAddress)
+		})
+
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/%s/dhcp/static_lease/%s", version, MACAddress)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool                      `json:"success"`
+							Result  types.DHCPStaticLeaseInfo `json:"result"`
+						}{
+							Success: true,
+							Result: types.DHCPStaticLeaseInfo{
+								ID:       "identifier",
+								IP:       IPAddress,
+								Mac:      MACAddress,
+								Comment:  CurrentSpecReport().FullText(),
+								Hostname: "test-hostname",
+								Host: types.LanInterfaceHost{
+									L2Ident: types.L2Ident{
+										ID:   MACAddress,
+										Type: types.MacAddress,
+									},
+									Active:     true,
+									Persistent: true,
+									Names: []types.HostName{
+										{
+											Name:   "test",
+											Source: "dhcp",
+										},
+									},
+									VendorName:        "vendor",
+									Type:              "workstation",
+									Reachable:         true,
+									PrimaryNameManual: true,
+									Interface:         "pub",
+									ID:                "ether-7e:ec:37:cd:5b:6a",
+									LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+									FirstActivity:     types.Timestamp{Time: time.Unix(1682578724, 0)},
+									LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+									PrimaryName:       "testing",
+									DefaultName:       "testing",
+									L3Connectivities: []types.L3Connectivity{
+										{
+											Address:           IPAddress,
+											Active:            true,
+											Reachable:         true,
+											LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+											Type:              "ipv4",
+											LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+										},
+									},
+								},
+							},
+						}),
+					),
+				)
+			})
+
+			It("should return the DHCP static lease", func() {
+				Expect(*returnedErr).ToNot(HaveOccurred())
+				Expect(*returnedDHCPStaticLease).To(gstruct.MatchAllFields(gstruct.Fields{
+					"ID":       Equal("identifier"),
+					"IP":       Equal(IPAddress),
+					"Mac":      Equal(MACAddress),
+					"Comment":  Equal(CurrentSpecReport().FullText()),
+					"Hostname": Equal("test-hostname"),
+					"Host": gstruct.MatchAllFields(gstruct.Fields{
+						"L2Ident": gstruct.MatchAllFields(gstruct.Fields{
+							"ID":   Equal(MACAddress),
+							"Type": Equal(types.MacAddress),
+						}),
+						"Active":     BeTrue(),
+						"Persistent": BeTrue(),
+						"Names": ConsistOf(gstruct.MatchAllFields(gstruct.Fields{
+							"Name":   Equal("test"),
+							"Source": Equal("dhcp"),
+						})),
+						"VendorName":        Equal("vendor"),
+						"Type":              Equal("workstation"),
+						"Reachable":         BeTrue(),
+						"PrimaryNameManual": BeTrue(),
+						"Interface":         Equal("pub"),
+						"ID":                Equal("ether-7e:ec:37:cd:5b:6a"),
+						"LastTimeReachable": gstruct.MatchAllFields(gstruct.Fields{
+							"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+						}),
+						"FirstActivity": gstruct.MatchAllFields(gstruct.Fields{
+							"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+						}),
+						"LastActivity": gstruct.MatchAllFields(gstruct.Fields{
+							"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+						}),
+						"PrimaryName": Equal("testing"),
+						"DefaultName": Equal("testing"),
+						"L3Connectivities": ConsistOf(gstruct.MatchAllFields(gstruct.Fields{
+							"Address":   Equal(IPAddress),
+							"Active":    BeTrue(),
+							"Reachable": BeTrue(),
+							"LastActivity": gstruct.MatchAllFields(gstruct.Fields{
+								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+							}),
+							"Type": Equal("ipv4"),
+							"LastTimeReachable": gstruct.MatchAllFields(gstruct.Fields{
+								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
+							}),
+						})),
+					}),
+				}))
+			})
+		})
+
+		Context("when the server returns an error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/%s/dhcp/static_lease/%s", version, MACAddress)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool `json:"success"`
+						}{
+							Success: false,
+						}),
+					),
+				)
+			})
+
+			It("should return an error", func() {
+				Expect(*returnedErr).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("UpdateDHCPStaticLease", func() {
+		const (
+			IPAddress  = "192.168.1.12"
+			MACAddress = "00:11:22:33:44:57"
+		)
+
+		returnedDHCPStaticLease := new(types.LanInterfaceHost)
+
+		JustBeforeEach(func(ctx SpecContext) {
+			*returnedDHCPStaticLease, *returnedErr = freeboxClient.UpdateDHCPStaticLease(ctx, MACAddress, types.DHCPStaticLeasePayload{
+				Comment: CurrentSpecReport().FullText(),
+			})
+		})
+
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/%s/dhcp/static_lease/%s", version, MACAddress)),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSONRepresenting(map[string]interface{}{
+							"comment": CurrentSpecReport().FullText(),
+						}),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool                   `json:"success"`
+							Result  types.LanInterfaceHost `json:"result"`
+						}{
+							Success: true,
+							Result: types.LanInterfaceHost{
+								Active:            true,
+								Persistent:        true,
+								Reachable:         true,
+								PrimaryNameManual: true,
+								VendorName:        "vendor",
+								Type:              "workstation",
+								Interface:         "pub",
+								ID:                "ether-7e:ec:37:cd:5b:6a",
+								LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+								FirstActivity:     types.Timestamp{Time: time.Unix(1682578724, 0)},
+								LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+								PrimaryName:       "testing",
+								DefaultName:       "testing",
+								L2Ident: types.L2Ident{
+									ID:   MACAddress,
+									Type: types.MacAddress,
+								},
+								Names: []types.HostName{
+									{
+										Name:   "test",
+										Source: "dhcp",
+									},
+								},
+								L3Connectivities: []types.L3Connectivity{
+									{
+										Address:           IPAddress,
+										Active:            true,
+										Reachable:         true,
+										LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+										Type:              "ipv4",
+										LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+									},
+								},
+							},
+						}),
+					),
+				)
+			})
+		})
+
+		Context("when the server returns an error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/%s/dhcp/static_lease/%s", version, MACAddress)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool `json:"success"`
+						}{
+							Success: false,
+						}),
+					),
+				)
+			})
+
+			It("should return an error", func() {
+				Expect(*returnedErr).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("CreateDHCPStaticLease", func() {
+		const (
+			IPAddress  = "192.168.1.13"
+			MACAddress = "00:11:22:33:44:58"
+		)
+
+		returnedDHCPStaticLease := new(types.LanInterfaceHost)
+
+		JustBeforeEach(func(ctx SpecContext) {
+			*returnedDHCPStaticLease, *returnedErr = freeboxClient.CreateDHCPStaticLease(ctx, types.DHCPStaticLeasePayload{
+				Comment:  CurrentSpecReport().FullText(),
+				Mac:      MACAddress,
+				Hostname: "test-hostname",
+				IP:       IPAddress,
+			})
+		})
+
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", fmt.Sprintf("/api/%s/dhcp/static_lease/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSONRepresenting(map[string]interface{}{
+							"comment":  CurrentSpecReport().FullText(),
+							"mac":      MACAddress,
+							"hostname": "test-hostname",
+							"ip":       IPAddress,
+						}),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool                   `json:"success"`
+							Result  types.LanInterfaceHost `json:"result"`
+						}{
+							Success: true,
+							Result: types.LanInterfaceHost{
+								Active:            true,
+								Persistent:        true,
+								Reachable:         true,
+								PrimaryNameManual: true,
+								VendorName:        "vendor",
+								Type:              "workstation",
+								Interface:         "pub",
+								ID:                "ether-7e:ec:37:cd:5b:6a",
+								LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+								FirstActivity:     types.Timestamp{Time: time.Unix(1682578724, 0)},
+								LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+								PrimaryName:       "testing",
+								DefaultName:       "testing",
+								L2Ident: types.L2Ident{
+									ID:   MACAddress,
+									Type: types.MacAddress,
+								},
+								Names: []types.HostName{
+									{
+										Name:   "test",
+										Source: "dhcp",
+									},
+								},
+								L3Connectivities: []types.L3Connectivity{
+									{
+										Address:           IPAddress,
+										Active:            true,
+										Reachable:         true,
+										LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
+										Type:              "ipv4",
+										LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
+									},
+								},
+							},
+						}),
+					),
+				)
+			})
+		})
+
+		Context("when the server returns an error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", fmt.Sprintf("/api/%s/dhcp/static_lease/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, struct {
+							Success bool `json:"success"`
+						}{
+							Success: false,
+						}),
+					),
+				)
+			})
+
+			It("should return an error", func() {
+				Expect(*returnedErr).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/types/dhcp_static.go
+++ b/types/dhcp_static.go
@@ -1,0 +1,17 @@
+package types
+
+type DHCPStaticLeaseInfo struct {
+	ID       string           `json:"id"`       // DHCP static lease object id
+	Mac      string           `json:"mac"`      // Host mac address`
+	Comment  string           `json:"comment"`  // an optional comment
+	Hostname string           `json:"hostname"` // hostname matching the mac address
+	IP       string           `json:"ip"`       // IPv4 to assign to the host
+	Host     LanInterfaceHost `json:"host"`     // LAN host information from LAN browser (refer to LanHost documentation)
+}
+
+type DHCPStaticLeasePayload struct {
+	Mac      string `json:"mac,omitempty"`      // Host mac address`
+	Comment  string `json:"comment,omitempty"`  // an optional comment
+	Hostname string `json:"hostname,omitempty"` // hostname matching the mac address
+	IP       string `json:"ip,omitempty"`       // IPv4 to assign to the host
+}

--- a/types/lan_browser.go
+++ b/types/lan_browser.go
@@ -66,12 +66,13 @@ type HostName struct {
 type l2IdentType = string
 
 const (
-	DHCP    l2IdentType = "dhcp"
-	NetBios l2IdentType = "netbios"
-	MDNS    l2IdentType = "mdns"
-	MDNSSRV l2IdentType = "mdns_srv"
-	UPNP    l2IdentType = "upnp"
-	WSD     l2IdentType = "wsd"
+	DHCP       l2IdentType = "dhcp"
+	NetBios    l2IdentType = "netbios"
+	MDNS       l2IdentType = "mdns"
+	MDNSSRV    l2IdentType = "mdns_srv"
+	UPNP       l2IdentType = "upnp"
+	WSD        l2IdentType = "wsd"
+	MacAddress l2IdentType = "mac_address"
 )
 
 type L2Ident struct {


### PR DESCRIPTION
The plan for the DHCP API is missing. Adding it.

Implements the calls to DHCP static lease endpoints.