### PR TITLE
feat(api/upload) Introduce file upload methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ At the time of this writing, generating credentials can only be done via the Fre
   - [x] Update a download task
   - [ ] Get a download log
   - [x] Add a new download task
+- [x] [Upload API](https://dev.freebox.fr/sdk/os/upload/) : `/upload/*`
+  - [x] Get an upload task
+  - [x] List upload tasks
+  - [x] Delete an upload task
+  - [x] Cancel an upload task
+  - [x] Cleanup upload tasks
+  - [x] Start a new upload
 - [ ] [Filesystem API](https://dev.freebox.fr/sdk/os/fs/) : `/fs/*`
   - [x] Get file information
   - [x] Download a file

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -78,6 +79,13 @@ type Client interface {
 	DeleteDownloadTask(ctx context.Context, identifier int64) error
 	EraseDownloadTask(ctx context.Context, identifier int64) error
 	UpdateDownloadTask(ctx context.Context, identifier int64, payload types.DownloadTaskUpdate) error
+	// uploads
+	FileUploadStart(ctx context.Context, input types.FileUploadStartActionInput) (io.WriteCloser, error)
+	GetUploadTask(ctx context.Context, identifier int64) (*types.UploadTask, error)
+	ListUploadTasks(ctx context.Context) ([]types.UploadTask, error)
+	CancelUploadTask(ctx context.Context, identifier int64) error
+	DeleteUploadTask(ctx context.Context, identifier int64) error
+	CleanUploadTasks(ctx context.Context) error
 }
 
 type HTTPClient interface {

--- a/client/events.go
+++ b/client/events.go
@@ -72,7 +72,7 @@ func (c *client) ListenEvents(ctx context.Context, events []types.EventDescripti
 		return nil, fmt.Errorf("registering to websocket notifications failed with error %s: %s", response.ErrorCode, response.Message)
 	}
 
-	channel := make(chan types.Event)
+	channel := make(chan types.Event, 10)
 	go func() {
 		var err error
 		defer func() {

--- a/client/file_upload.go
+++ b/client/file_upload.go
@@ -1,0 +1,235 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+const codeUploadTaskNotFound = "noent"
+
+func (c *client) FileUploadStart(ctx context.Context, input types.FileUploadStartActionInput) (io.WriteCloser, error) {
+	header := http.Header{}
+	if err := c.withSession(ctx)(&http.Request{
+		Header: header,
+	}); err != nil {
+		return nil, fmt.Errorf("get a session: %w", err)
+	}
+
+	url := *c.base
+	url.Scheme = "ws"
+	if strings.ToLower(c.base.Scheme) == "https" {
+		url.Scheme = "wss"
+	}
+	url.Path = fmt.Sprintf("%s/ws/upload", url.Path)
+
+	ws, dialResponse, err := websocket.DefaultDialer.DialContext(ctx, url.String(), header)
+	if err != nil {
+		return nil, fmt.Errorf("dialing websocket returned a status %s: %w", dialResponse.Status, err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = ws.Close()
+	}()
+
+	requestID := newRequestID()
+
+	if err := ws.WriteJSON(&types.FileUploadStartAction{
+		Action:    types.FileUploadStartActionNameUploadStart,
+		Size:      input.Size,
+		RequestID: requestID,
+		Dirname:   input.Dirname,
+		Filename:  input.Filename,
+		Force:     input.Force,
+	}); err != nil {
+		return nil, fmt.Errorf("upload start action: %w", err)
+	}
+
+	if _, err := waitJSONResponse(ctx, ws, &types.WebSocketResponse[interface{}]{}, requestID, types.FileUploadStartActionNameUploadStart); err != nil {
+		return nil, fmt.Errorf("upload start confirmation: %w", err)
+	}
+
+	// caller should close the writer
+	return &ChunkWriter{
+		Conn:      ws,
+		RequestID: requestID,
+		written:   0,
+		expected:  input.Size,
+	}, nil
+}
+
+// ListUploadTasks returns a list of upload tasks.
+func (c *client) ListUploadTasks(ctx context.Context) ([]types.UploadTask, error) {
+	response, err := c.get(ctx, "upload/", c.withSession(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("GET upload/ endpoint: %w", err)
+	}
+
+	if response.Result == nil {
+		return nil, nil
+	}
+
+	var result []types.UploadTask
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return nil, fmt.Errorf("upload tasks from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetUploadTask returns a upload task by its identifier.
+func (c *client) GetUploadTask(ctx context.Context, identifier int64) (*types.UploadTask, error) {
+	response, err := c.get(ctx, fmt.Sprintf("upload/%d", identifier), c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeTaskNotFound {
+			return nil, ErrTaskNotFound
+		}
+		return nil, fmt.Errorf("GET upload/%d endpoint: %w", identifier, err)
+	}
+
+	var result types.UploadTask
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return nil, fmt.Errorf("upload task from generic response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// CancelUploadTask cancels a upload task by its identifier.
+func (c *client) CancelUploadTask(ctx context.Context, identifier int64) error {
+	response, err := c.delete(ctx, fmt.Sprintf("upload/%d/cancel", identifier), nil, c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeTaskNotFound {
+			return ErrTaskNotFound
+		}
+
+		return fmt.Errorf("DELETE upload/%d/cancel endpoint: %w", identifier, err)
+	}
+
+	return nil
+}
+
+// DeleteUploadTask deletes a upload task by its identifier.
+func (c *client) DeleteUploadTask(ctx context.Context, identifier int64) error {
+	response, err := c.delete(ctx, fmt.Sprintf("upload/%d", identifier), c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeUploadTaskNotFound {
+			return ErrTaskNotFound
+		}
+		return fmt.Errorf("DELETE upload/%d endpoint: %w", identifier, err)
+	}
+
+	return nil
+}
+
+// CleanUploadTasks deletes all the FileUpload not in_progress.
+func (c *client) CleanUploadTasks(ctx context.Context) error {
+	_, err := c.delete(ctx, "upload/clean", c.withSession(ctx))
+	if err != nil {
+		return fmt.Errorf("DELETE upload/clean endpoint: %w", err)
+	}
+
+	return nil
+}
+
+func newRequestID() types.UploadRequestID {
+	return types.UploadRequestID(time.Now().Nanosecond())
+}
+
+type ChunkWriter struct {
+	*websocket.Conn
+
+	RequestID         types.UploadRequestID
+	lock              sync.Mutex
+	expected, written int
+}
+
+var _ io.WriteCloser = (*ChunkWriter)(nil)
+
+func (w *ChunkWriter) Write(p []byte) (n int, err error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if err := w.Conn.WriteMessage(websocket.BinaryMessage, p); err != nil {
+		return 0, err
+	}
+
+	responseData, err := waitJSONResponse(context.Background(), w.Conn, &types.WebSocketResponse[types.FileUploadChunkResponse]{}, w.RequestID, types.FileUploadStartActionNameUploadData)
+	if err != nil {
+		return 0, fmt.Errorf("chunk upload confirmation: %w", err)
+	}
+
+	written := responseData.TotalLen - w.written
+	w.written = responseData.TotalLen
+
+	if responseData.Cancelled {
+		return written, errors.New("upload cancelled")
+	}
+
+	if written != len(p) {
+		return written, io.ErrShortWrite
+	}
+
+	return written, nil
+}
+
+func (w *ChunkWriter) Close() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	switch w.written {
+	case w.expected:
+		if err := w.Conn.WriteJSON(&types.FileUploadFinalize{
+			Action:    types.FileUploadStartActionNameUploadFinalize,
+			RequestID: w.RequestID,
+		}); err != nil {
+			return fmt.Errorf("finalize upload: %w", err)
+		}
+
+	default:
+		if err := w.Conn.WriteJSON(&types.FileUploadFinalize{
+			Action:    types.FileUploadStartActionNameUploadCancel,
+			RequestID: w.RequestID,
+		}); err != nil {
+			return fmt.Errorf("cancel upload: %w", err)
+		}
+
+		if _, err := waitJSONResponse(context.Background(), w.Conn, &types.WebSocketResponse[types.FileUploadCancelAction]{}, w.RequestID, types.FileUploadStartActionNameUploadCancel); err != nil {
+			return fmt.Errorf("cancel upload confirmation: %w", err)
+		}
+	}
+
+	w.Conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+
+	return w.Conn.Close()
+}
+
+func waitJSONResponse[R interface{}](ctx context.Context, ws *websocket.Conn, message *types.WebSocketResponse[R], requestID types.UploadRequestID, action types.WebSocketAction) (*R, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			if err := ws.ReadJSON(message); err != nil {
+				return nil, fmt.Errorf("read websocket response: %w", err)
+			}
+
+			if err := message.GetError(); err != nil {
+				return nil, fmt.Errorf("upload start: %w", err)
+			}
+
+			if message.RequestID == types.WebSocketRequestID(requestID) && message.Action == action {
+				return &message.Result, nil
+			}
+		}
+	}
+}

--- a/client/file_upload_test.go
+++ b/client/file_upload_test.go
@@ -1,0 +1,452 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/onsi/gomega/gstruct"
+
+	"github.com/nikolalohinski/free-go/client"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("FileUpload", func() {
+	var (
+		freeboxClient client.Client
+
+		server   *ghttp.Server
+		endpoint = new(string)
+
+		uploadContext context.Context
+
+		sessionToken = new(string)
+
+		returnedWriter io.WriteCloser
+		returnedErr    = new(error)
+
+		content []byte
+		size    int
+
+		ws *websocket.Conn
+	)
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		DeferCleanup(server.Close)
+		*endpoint = server.Addr()
+
+		freeboxClient = Must(client.New(*endpoint, version)).
+			WithAppID(appID).
+			WithPrivateToken(privateToken)
+
+		*sessionToken = setupLoginFlow(server)
+
+		content = []byte("data")
+		size = len(content)
+
+		uploadContext = context.Background()
+
+		ws = new(websocket.Conn)
+	})
+
+	JustBeforeEach(func() {
+		ctx, cancel := context.WithTimeout(uploadContext, 10*time.Second)
+		DeferCleanup(cancel)
+
+		returnedWriter, *returnedErr = freeboxClient.FileUploadStart(ctx, types.FileUploadStartActionInput{
+			Dirname:  "dir",
+			Filename: "the-file",
+			Force:    types.FileUploadStartActionForceOverwrite,
+			Size:     size,
+		})
+	})
+
+	Describe("FileUploadStart", func() {
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
+					var err error
+					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
+					Expect(err).ToNot(HaveOccurred())
+
+					defer ws.Close()
+
+					ws.SetCloseHandler(func(code int, text string) error {
+						// Ignore default close handler to explicitly assert the websocket is closed correctly
+						Expect(code).To(Equal(websocket.CloseNormalClosure))
+						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+
+						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
+						return nil
+					})
+
+					var result types.FileUploadStartAction
+					Expect(readJSON(ws, &result)).To(Succeed())
+					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+						"Size":     BeEquivalentTo(4),
+						"Dirname":  BeEquivalentTo("dir"),
+						"Filename": Equal("the-file"),
+						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+					}))
+					Expect(result.RequestID).To(BeNumerically(">", 0))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadStart,
+						RequestID: result.RequestID,
+					})).To(Succeed())
+
+					messageType, reader, err := ws.NextReader()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(messageType).To(Equal(websocket.BinaryMessage))
+					received, err := io.ReadAll(gbytes.TimeoutReader(reader, time.Second))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(received)).To(Equal(string(content)))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadData,
+						RequestID: result.RequestID,
+						Result: types.FileUploadChunkResponse{
+							TotalLen: len(received),
+							Complete: false,
+						},
+					})).To(Succeed())
+
+					var finalize types.FileUploadFinalize
+					Expect(readJSON(ws, &finalize)).To(Succeed())
+					Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
+						"RequestID": BeEquivalentTo(result.RequestID),
+					}))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadFinalize,
+						RequestID: result.RequestID,
+						Result: types.FileUploadFinalizeResponse{
+							TotalLen:  len(received),
+							Complete:  true,
+							Cancelled: false,
+						},
+					})).To(Succeed())
+				})
+			})
+
+			It("should start a file upload", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(returnedWriter).ToNot(BeNil())
+
+				Expect(returnedWriter.Write(content)).To(BeEquivalentTo(size))
+
+				Expect(returnedWriter.Close()).To(Succeed())
+			})
+		})
+
+		Context("File already exist", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
+					var err error
+					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
+					Expect(err).ToNot(HaveOccurred())
+
+					defer ws.Close()
+
+					ws.SetCloseHandler(func(code int, text string) error {
+						// Ignore default close handler to explicitly assert the websocket is closed correctly
+						Expect(code).To(Equal(websocket.CloseNormalClosure))
+						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+
+						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
+						return nil
+					})
+
+					var result types.FileUploadStartAction
+					Expect(readJSON(ws, &result)).To(Succeed())
+					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+						"Size":     BeEquivalentTo(4),
+						"Dirname":  BeEquivalentTo("dir"),
+						"Filename": Equal("the-file"),
+						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+					}))
+					Expect(result.RequestID).To(BeNumerically(">", 0))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
+						Success:   false,
+						Action:    types.FileUploadStartActionNameUploadStart,
+						RequestID: result.RequestID,
+						ErrorCode: "conflict",
+						Message:   "Le fichier existe déjà",
+					})).To(Succeed())
+				})
+			})
+
+			It("conflicts", func() {
+				Expect(*returnedErr).To(MatchError(ContainSubstring("conflict: Le fichier existe déjà")))
+			})
+		})
+
+		Context("with non JSON message", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
+					var err error
+					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
+					Expect(err).ToNot(HaveOccurred())
+
+					defer ws.Close()
+
+					ws.NetConn().Write([]byte("invalid message"))
+				})
+			})
+
+			It("fails", func() {
+				Expect(*returnedErr).To(HaveOccurred())
+			})
+		})
+
+		Context("Websocket close early", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
+					var err error
+					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(ws.Close()).To(Succeed())
+				})
+			})
+
+			It("propagate the error", func() {
+				Expect(*returnedErr).To(MatchError(Or(ContainSubstring("connection reset by peer"), ContainSubstring("unexpected EOF"))))
+			})
+		})
+
+		Context("upload error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
+					var err error
+					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
+					Expect(err).ToNot(HaveOccurred())
+
+					defer ws.Close()
+
+					ws.SetCloseHandler(func(code int, text string) error {
+						// Ignore default close handler to explicitly assert the websocket is closed correctly
+						Expect(code).To(Equal(websocket.CloseNormalClosure))
+						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+
+						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
+						return nil
+					})
+
+					var result types.FileUploadStartAction
+					Expect(readJSON(ws, &result)).To(Succeed())
+					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+						"Size":     BeEquivalentTo(4),
+						"Dirname":  BeEquivalentTo("dir"),
+						"Filename": Equal("the-file"),
+						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+					}))
+					Expect(result.RequestID).To(BeNumerically(">", 0))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadStart,
+						RequestID: result.RequestID,
+					})).To(Succeed())
+
+					messageType, reader, err := ws.NextReader()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(messageType).To(Equal(websocket.BinaryMessage))
+					received, err := io.ReadAll(gbytes.TimeoutReader(reader, time.Second))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(received)).To(Equal(string(content)))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+						Success:   false,
+						Action:    types.FileUploadStartActionNameUploadFinalize,
+						RequestID: result.RequestID,
+						ErrorCode: "test_error",
+						Message:   "no space left on device",
+					})).To(Succeed())
+
+					var cancel types.FileUploadCancelAction
+					Expect(readJSON(ws, &cancel)).To(Succeed())
+					Expect(cancel).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadCancel),
+						"RequestID": BeEquivalentTo(result.RequestID),
+					}))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadCancelResponse]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadCancel,
+						RequestID: result.RequestID,
+						Result: types.FileUploadCancelResponse{
+							Cancelled: true,
+						},
+					})).To(Succeed())
+				})
+			})
+
+			It("propagate the error", func() {
+				Expect(*returnedErr).To(Succeed())
+				_, err := returnedWriter.Write(content)
+				Expect(err).To(MatchError(ContainSubstring("test_error: no space left on device")))
+
+				Expect(returnedWriter.Close()).To(Succeed())
+			})
+		})
+
+		Context("ignore message with a different requestID", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
+					var err error
+					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
+					Expect(err).ToNot(HaveOccurred())
+
+					defer ws.Close()
+
+					ws.SetCloseHandler(func(code int, text string) error {
+						// Ignore default close handler to explicitly assert the websocket is closed correctly
+						Expect(code).To(Equal(websocket.CloseNormalClosure))
+						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+
+						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
+						return nil
+					})
+
+					var result types.FileUploadStartAction
+					Expect(readJSON(ws, &result)).To(Succeed())
+					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+						"Size":     BeEquivalentTo(4),
+						"Dirname":  BeEquivalentTo("dir"),
+						"Filename": Equal("the-file"),
+						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+					}))
+					Expect(result.RequestID).To(BeNumerically(">", 0))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadStart,
+						RequestID: result.RequestID,
+					})).To(Succeed())
+
+					messageType, reader, err := ws.NextReader()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(messageType).To(Equal(websocket.BinaryMessage))
+					received, err := io.ReadAll(gbytes.TimeoutReader(reader, time.Second))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(received)).To(Equal(string(content)))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadData,
+						RequestID: result.RequestID,
+						Result: types.FileUploadChunkResponse{
+							TotalLen: len(received),
+							Complete: false,
+						},
+					})).To(Succeed())
+
+					var finalize types.FileUploadFinalize
+					Expect(readJSON(ws, &finalize)).To(Succeed())
+					Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
+						"RequestID": BeEquivalentTo(result.RequestID),
+					}))
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+						Success:   false,
+						Action:    types.FileUploadStartActionNameUploadFinalize,
+						RequestID: result.RequestID + 1,
+						ErrorCode: "error_to_ignore",
+						Message:   "This error is addressed to another request",
+					})).To(Succeed())
+
+					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+						Success:   true,
+						Action:    types.FileUploadStartActionNameUploadFinalize,
+						RequestID: result.RequestID,
+						Result: types.FileUploadFinalizeResponse{
+							TotalLen:  len(received),
+							Complete:  true,
+							Cancelled: false,
+						},
+					})).To(Succeed())
+				})
+			})
+
+			It("ignore the message", func() {
+				Expect(*returnedErr).To(Succeed())
+				Expect(returnedWriter).ToNot(BeNil())
+
+				Expect(returnedWriter.Write(content)).To(BeEquivalentTo(size))
+
+				Expect(returnedWriter.Close()).To(Succeed())
+			})
+		})
+	})
+})
+
+func writeJSON(ws *websocket.Conn, data interface{}) error {
+	w, err := ws.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		return fmt.Errorf("next writer: %w", err)
+	}
+
+	if err := json.NewEncoder(gbytes.TimeoutWriter(w, time.Second)).Encode(data); err != nil {
+		return fmt.Errorf("write json: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("close writer: %w", err)
+	}
+
+	return nil
+}
+
+func readJSON(ws *websocket.Conn, result interface{}) error {
+	messageType, reader, err := ws.NextReader()
+	if err != nil {
+		return fmt.Errorf("next reader: %w", err)
+	}
+	if messageType != websocket.TextMessage {
+		return fmt.Errorf("unexpected message type: %d", messageType)
+	}
+
+	if err := json.NewDecoder(gbytes.TimeoutReader(reader, time.Second)).Decode(result); err != nil {
+		return fmt.Errorf("read json: %w", err)
+	}
+
+	return nil
+}

--- a/client/file_upload_test.go
+++ b/client/file_upload_test.go
@@ -22,47 +22,39 @@ import (
 var _ = Describe("FileUpload", func() {
 	var (
 		freeboxClient client.Client
-
-		server   *ghttp.Server
-		endpoint = new(string)
+		server        *ghttp.Server
+		sessionToken  string
 
 		uploadContext context.Context
 
-		sessionToken = new(string)
-
 		returnedWriter io.WriteCloser
-		returnedErr    = new(error)
+		returnedErr    error
 
 		content []byte
 		size    int
-
-		ws *websocket.Conn
 	)
 
 	BeforeEach(func() {
 		server = ghttp.NewServer()
 		DeferCleanup(server.Close)
-		*endpoint = server.Addr()
 
-		freeboxClient = Must(client.New(*endpoint, version)).
+		freeboxClient = Must(client.New(server.Addr(), version)).
 			WithAppID(appID).
 			WithPrivateToken(privateToken)
 
-		*sessionToken = setupLoginFlow(server)
+		sessionToken = setupLoginFlow(server)
 
 		content = []byte("data")
 		size = len(content)
 
 		uploadContext = context.Background()
-
-		ws = new(websocket.Conn)
 	})
 
 	JustBeforeEach(func() {
 		ctx, cancel := context.WithTimeout(uploadContext, 10*time.Second)
 		DeferCleanup(cancel)
 
-		returnedWriter, *returnedErr = freeboxClient.FileUploadStart(ctx, types.FileUploadStartActionInput{
+		returnedWriter, returnedErr = freeboxClient.FileUploadStart(ctx, types.FileUploadStartActionInput{
 			Dirname:  "dir",
 			Filename: "the-file",
 			Force:    types.FileUploadStartActionForceOverwrite,
@@ -73,81 +65,77 @@ var _ = Describe("FileUpload", func() {
 	Describe("FileUploadStart", func() {
 		Context("default", func() {
 			BeforeEach(func() {
-				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
-					defer GinkgoRecover()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							ws.SetCloseHandler(func(code int, text string) error {
+								defer GinkgoRecover()
 
-					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
-					var err error
-					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
-					Expect(err).ToNot(HaveOccurred())
+								// Ignore default close handler to explicitly assert the websocket is closed correctly
+								Expect(code).To(Equal(websocket.CloseNormalClosure))
+								Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
 
-					defer ws.Close()
+								_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
-					ws.SetCloseHandler(func(code int, text string) error {
-						// Ignore default close handler to explicitly assert the websocket is closed correctly
-						Expect(code).To(Equal(websocket.CloseNormalClosure))
-						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+								return nil
+							})
 
-						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
-						return nil
-					})
+							var result types.FileUploadStartAction
+							Expect(readJSON(ws, &result)).To(Succeed())
+							Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+								"Size":     BeEquivalentTo(4),
+								"Dirname":  BeEquivalentTo("dir"),
+								"Filename": Equal("the-file"),
+								"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+							}))
+							Expect(result.RequestID).To(BeNumerically(">", 0))
 
-					var result types.FileUploadStartAction
-					Expect(readJSON(ws, &result)).To(Succeed())
-					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
-						"Size":     BeEquivalentTo(4),
-						"Dirname":  BeEquivalentTo("dir"),
-						"Filename": Equal("the-file"),
-						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
-					}))
-					Expect(result.RequestID).To(BeNumerically(">", 0))
+							Expect(writeJSON(ws, &types.FileUploadStartResponse{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadStart,
+								RequestID: result.RequestID,
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadStart,
-						RequestID: result.RequestID,
-					})).To(Succeed())
+							received, err := readChunk(ws)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(string(received)).To(Equal(string(content)))
 
-					messageType, reader, err := ws.NextReader()
-					Expect(err).ToNot(HaveOccurred())
-					Expect(messageType).To(Equal(websocket.BinaryMessage))
-					received, err := io.ReadAll(gbytes.TimeoutReader(reader, time.Second))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(string(received)).To(Equal(string(content)))
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadData,
+								RequestID: result.RequestID,
+								Result: types.FileUploadChunkResponse{
+									TotalLen: len(received),
+									Complete: false,
+								},
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadData,
-						RequestID: result.RequestID,
-						Result: types.FileUploadChunkResponse{
-							TotalLen: len(received),
-							Complete: false,
-						},
-					})).To(Succeed())
+							var finalize types.FileUploadFinalize
+							Expect(readJSON(ws, &finalize)).To(Succeed())
+							Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
+								"RequestID": BeEquivalentTo(result.RequestID),
+							}))
 
-					var finalize types.FileUploadFinalize
-					Expect(readJSON(ws, &finalize)).To(Succeed())
-					Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
-						"RequestID": BeEquivalentTo(result.RequestID),
-					}))
-
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadFinalize,
-						RequestID: result.RequestID,
-						Result: types.FileUploadFinalizeResponse{
-							TotalLen:  len(received),
-							Complete:  true,
-							Cancelled: false,
-						},
-					})).To(Succeed())
-				})
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadFinalize,
+								RequestID: result.RequestID,
+								Result: types.FileUploadFinalizeResponse{
+									TotalLen:  len(received),
+									Complete:  true,
+									Cancelled: false,
+								},
+							})).To(Succeed())
+						}),
+					),
+				)
 			})
 
 			It("should start a file upload", func() {
-				Expect(*returnedErr).To(BeNil())
+				Expect(returnedErr).To(BeNil())
 				Expect(returnedWriter).ToNot(BeNil())
 
 				Expect(returnedWriter.Write(content)).To(BeEquivalentTo(size))
@@ -158,164 +146,255 @@ var _ = Describe("FileUpload", func() {
 
 		Context("File already exist", func() {
 			BeforeEach(func() {
-				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
-					defer GinkgoRecover()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							ws.SetCloseHandler(func(code int, text string) error {
+								defer GinkgoRecover()
 
-					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
-					var err error
-					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
-					Expect(err).ToNot(HaveOccurred())
+								// Ignore default close handler to explicitly assert the websocket is closed correctly
+								Expect(code).To(Equal(websocket.CloseNormalClosure))
+								Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
 
-					defer ws.Close()
+								_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
-					ws.SetCloseHandler(func(code int, text string) error {
-						// Ignore default close handler to explicitly assert the websocket is closed correctly
-						Expect(code).To(Equal(websocket.CloseNormalClosure))
-						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+								return nil
+							})
 
-						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
-						return nil
-					})
+							var result types.FileUploadStartAction
+							Expect(readJSON(ws, &result)).To(Succeed())
+							Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+								"Size":     BeEquivalentTo(4),
+								"Dirname":  BeEquivalentTo("dir"),
+								"Filename": Equal("the-file"),
+								"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+							}))
+							Expect(result.RequestID).To(BeNumerically(">", 0))
 
-					var result types.FileUploadStartAction
-					Expect(readJSON(ws, &result)).To(Succeed())
-					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
-						"Size":     BeEquivalentTo(4),
-						"Dirname":  BeEquivalentTo("dir"),
-						"Filename": Equal("the-file"),
-						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
-					}))
-					Expect(result.RequestID).To(BeNumerically(">", 0))
-
-					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
-						Success:   false,
-						Action:    types.FileUploadStartActionNameUploadStart,
-						RequestID: result.RequestID,
-						ErrorCode: "conflict",
-						Message:   "Le fichier existe déjà",
-					})).To(Succeed())
-				})
+							Expect(writeJSON(ws, &types.FileUploadStartResponse{
+								Success:   false,
+								Action:    types.FileUploadStartActionNameUploadStart,
+								RequestID: result.RequestID,
+								FileSize:  size,
+								ErrorCode: "conflict",
+								Message:   "Le fichier existe déjà",
+							})).To(Succeed())
+						}),
+					),
+				)
 			})
 
 			It("conflicts", func() {
-				Expect(*returnedErr).To(MatchError(ContainSubstring("conflict: Le fichier existe déjà")))
+				Expect(returnedErr).To(MatchError(&types.WebSocketResponseError{
+					ErrorCode: "conflict",
+					Message:   "Le fichier existe déjà",
+				}))
 			})
 		})
 
 		Context("with non JSON message", func() {
 			BeforeEach(func() {
-				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
-					defer GinkgoRecover()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							ws.SetCloseHandler(func(code int, text string) error {
+								defer GinkgoRecover()
 
-					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
-					var err error
-					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
-					Expect(err).ToNot(HaveOccurred())
+								// Ignore default close handler to explicitly assert the websocket is closed correctly
+								Expect(code).To(Equal(websocket.CloseNormalClosure))
+								Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
 
-					defer ws.Close()
+								_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
-					ws.NetConn().Write([]byte("invalid message"))
-				})
+								return nil
+							})
+
+							ws.NetConn().Write([]byte("invalid message"))
+						}),
+					),
+				)
 			})
 
 			It("fails", func() {
-				Expect(*returnedErr).To(HaveOccurred())
+				Expect(returnedErr).To(HaveOccurred())
 			})
 		})
 
 		Context("Websocket close early", func() {
 			BeforeEach(func() {
-				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
-					defer GinkgoRecover()
-
-					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
-					var err error
-					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(ws.Close()).To(Succeed())
-				})
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							// Do nothing and close the connection
+						}),
+					),
+				)
 			})
 
 			It("propagate the error", func() {
-				Expect(*returnedErr).To(MatchError(Or(ContainSubstring("connection reset by peer"), ContainSubstring("unexpected EOF"))))
+				Expect(returnedErr).To(MatchError(Or(ContainSubstring("connection reset by peer"), ContainSubstring("unexpected EOF"))))
+			})
+		})
+
+		Context("close error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							ws.SetCloseHandler(func(code int, text string) error {
+								defer GinkgoRecover()
+
+								// Ignore default close handler to explicitly assert the websocket is closed correctly
+								Expect(code).To(Equal(websocket.CloseNormalClosure))
+								Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+
+								_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "internal error"))
+
+								return nil
+							})
+
+							var result types.FileUploadStartAction
+							Expect(readJSON(ws, &result)).To(Succeed())
+							Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+								"Size":     BeEquivalentTo(4),
+								"Dirname":  BeEquivalentTo("dir"),
+								"Filename": Equal("the-file"),
+								"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+							}))
+							Expect(result.RequestID).To(BeNumerically(">", 0))
+
+							Expect(writeJSON(ws, &types.FileUploadStartResponse{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadStart,
+								RequestID: result.RequestID,
+							})).To(Succeed())
+
+							received, err := readChunk(ws)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(string(received)).To(Equal(string(content)))
+
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadData,
+								RequestID: result.RequestID,
+								Result: types.FileUploadChunkResponse{
+									TotalLen: len(received),
+									Complete: false,
+								},
+							})).To(Succeed())
+
+							var finalize types.FileUploadFinalize
+							Expect(readJSON(ws, &finalize)).To(Succeed())
+							Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
+								"RequestID": BeEquivalentTo(result.RequestID),
+							}))
+
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadFinalize,
+								RequestID: result.RequestID,
+								Result: types.FileUploadFinalizeResponse{
+									TotalLen:  len(received),
+									Complete:  true,
+									Cancelled: false,
+								},
+							})).To(Succeed())
+						}),
+					),
+				)
+			})
+
+			It("should start a file upload", func() {
+				Expect(returnedErr).To(BeNil())
+				Expect(returnedWriter).ToNot(BeNil())
+
+				Expect(returnedWriter.Write(content)).To(BeEquivalentTo(size))
+
+				Expect(returnedWriter.Close()).To(Succeed())
 			})
 		})
 
 		Context("upload error", func() {
 			BeforeEach(func() {
-				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
-					defer GinkgoRecover()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							ws.SetCloseHandler(func(code int, text string) error {
+								defer GinkgoRecover()
 
-					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
-					var err error
-					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
-					Expect(err).ToNot(HaveOccurred())
+								// Ignore default close handler to explicitly assert the websocket is closed correctly
+								Expect(code).To(Equal(websocket.CloseNormalClosure))
+								Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
 
-					defer ws.Close()
+								_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
-					ws.SetCloseHandler(func(code int, text string) error {
-						// Ignore default close handler to explicitly assert the websocket is closed correctly
-						Expect(code).To(Equal(websocket.CloseNormalClosure))
-						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+								return nil
+							})
 
-						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
-						return nil
-					})
+							var result types.FileUploadStartAction
+							Expect(readJSON(ws, &result)).To(Succeed())
+							Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+								"Size":     BeEquivalentTo(4),
+								"Dirname":  BeEquivalentTo("dir"),
+								"Filename": Equal("the-file"),
+								"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+							}))
+							Expect(result.RequestID).To(BeNumerically(">", 0))
 
-					var result types.FileUploadStartAction
-					Expect(readJSON(ws, &result)).To(Succeed())
-					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
-						"Size":     BeEquivalentTo(4),
-						"Dirname":  BeEquivalentTo("dir"),
-						"Filename": Equal("the-file"),
-						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
-					}))
-					Expect(result.RequestID).To(BeNumerically(">", 0))
+							Expect(writeJSON(ws, &types.FileUploadStartResponse{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadStart,
+								RequestID: result.RequestID,
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadStart,
-						RequestID: result.RequestID,
-					})).To(Succeed())
+							received, err := readChunk(ws)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(string(received)).To(Equal(string(content)))
 
-					messageType, reader, err := ws.NextReader()
-					Expect(err).ToNot(HaveOccurred())
-					Expect(messageType).To(Equal(websocket.BinaryMessage))
-					received, err := io.ReadAll(gbytes.TimeoutReader(reader, time.Second))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(string(received)).To(Equal(string(content)))
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
+								Success:   false,
+								Action:    types.FileUploadStartActionNameUploadData,
+								RequestID: result.RequestID,
+								Result: types.FileUploadChunkResponse{
+									TotalLen:  len(received) - 1,
+									Complete:  false,
+									Cancelled: false,
+								},
+								ErrorCode: "test_error",
+								Message:   "no space left on device",
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
-						Success:   false,
-						Action:    types.FileUploadStartActionNameUploadFinalize,
-						RequestID: result.RequestID,
-						ErrorCode: "test_error",
-						Message:   "no space left on device",
-					})).To(Succeed())
+							var cancel types.FileUploadCancelAction
+							Expect(readJSON(ws, &cancel)).To(Succeed())
+							Expect(cancel).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadCancel),
+								"RequestID": BeEquivalentTo(result.RequestID),
+							}))
 
-					var cancel types.FileUploadCancelAction
-					Expect(readJSON(ws, &cancel)).To(Succeed())
-					Expect(cancel).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadCancel),
-						"RequestID": BeEquivalentTo(result.RequestID),
-					}))
-
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadCancelResponse]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadCancel,
-						RequestID: result.RequestID,
-						Result: types.FileUploadCancelResponse{
-							Cancelled: true,
-						},
-					})).To(Succeed())
-				})
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadCancelResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadCancel,
+								RequestID: result.RequestID,
+								Result: types.FileUploadCancelResponse{
+									Cancelled: true,
+								},
+							})).To(Succeed())
+						}),
+					),
+				)
 			})
 
 			It("propagate the error", func() {
-				Expect(*returnedErr).To(Succeed())
+				Expect(returnedErr).To(Succeed())
 				_, err := returnedWriter.Write(content)
 				Expect(err).To(MatchError(ContainSubstring("test_error: no space left on device")))
 
@@ -325,89 +404,85 @@ var _ = Describe("FileUpload", func() {
 
 		Context("ignore message with a different requestID", func() {
 			BeforeEach(func() {
-				server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
-					defer GinkgoRecover()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						verifyAuth(sessionToken),
+						wsHandler(func(ws *websocket.Conn) {
+							ws.SetCloseHandler(func(code int, text string) error {
+								defer GinkgoRecover()
 
-					Expect(r.Header[client.AuthHeader]).To(ContainElement(Equal(*sessionToken)))
-					var err error
-					ws, err = (&websocket.Upgrader{}).Upgrade(w, r, nil)
-					Expect(err).ToNot(HaveOccurred())
+								// Ignore default close handler to explicitly assert the websocket is closed correctly
+								Expect(code).To(Equal(websocket.CloseNormalClosure))
+								Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
 
-					defer ws.Close()
+								_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 
-					ws.SetCloseHandler(func(code int, text string) error {
-						// Ignore default close handler to explicitly assert the websocket is closed correctly
-						Expect(code).To(Equal(websocket.CloseNormalClosure))
-						Expect(text).To(Equal(websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+								return nil
+							})
 
-						Expect(ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))).To(Succeed())
-						return nil
-					})
+							var result types.FileUploadStartAction
+							Expect(readJSON(ws, &result)).To(Succeed())
+							Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
+								"Size":     BeEquivalentTo(4),
+								"Dirname":  BeEquivalentTo("dir"),
+								"Filename": Equal("the-file"),
+								"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
+							}))
+							Expect(result.RequestID).To(BeNumerically(">", 0))
 
-					var result types.FileUploadStartAction
-					Expect(readJSON(ws, &result)).To(Succeed())
-					Expect(result).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":   BeEquivalentTo(types.FileUploadStartActionNameUploadStart),
-						"Size":     BeEquivalentTo(4),
-						"Dirname":  BeEquivalentTo("dir"),
-						"Filename": Equal("the-file"),
-						"Force":    BeEquivalentTo(types.FileUploadStartActionForceOverwrite),
-					}))
-					Expect(result.RequestID).To(BeNumerically(">", 0))
+							Expect(writeJSON(ws, &types.FileUploadStartResponse{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadStart,
+								RequestID: result.RequestID,
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[interface{}]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadStart,
-						RequestID: result.RequestID,
-					})).To(Succeed())
+							received, err := readChunk(ws)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(string(received)).To(Equal(string(content)))
 
-					messageType, reader, err := ws.NextReader()
-					Expect(err).ToNot(HaveOccurred())
-					Expect(messageType).To(Equal(websocket.BinaryMessage))
-					received, err := io.ReadAll(gbytes.TimeoutReader(reader, time.Second))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(string(received)).To(Equal(string(content)))
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadData,
+								RequestID: result.RequestID,
+								Result: types.FileUploadChunkResponse{
+									TotalLen: len(received),
+									Complete: false,
+								},
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadChunkResponse]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadData,
-						RequestID: result.RequestID,
-						Result: types.FileUploadChunkResponse{
-							TotalLen: len(received),
-							Complete: false,
-						},
-					})).To(Succeed())
+							var finalize types.FileUploadFinalize
+							Expect(readJSON(ws, &finalize)).To(Succeed())
+							Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
+								"RequestID": BeEquivalentTo(result.RequestID),
+							}))
 
-					var finalize types.FileUploadFinalize
-					Expect(readJSON(ws, &finalize)).To(Succeed())
-					Expect(finalize).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action":    BeEquivalentTo(types.FileUploadStartActionNameUploadFinalize),
-						"RequestID": BeEquivalentTo(result.RequestID),
-					}))
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+								Success:   false,
+								Action:    types.FileUploadStartActionNameUploadFinalize,
+								RequestID: result.RequestID + 1,
+								ErrorCode: "error_to_ignore",
+								Message:   "This error is addressed to another request",
+							})).To(Succeed())
 
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
-						Success:   false,
-						Action:    types.FileUploadStartActionNameUploadFinalize,
-						RequestID: result.RequestID + 1,
-						ErrorCode: "error_to_ignore",
-						Message:   "This error is addressed to another request",
-					})).To(Succeed())
-
-					Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
-						Success:   true,
-						Action:    types.FileUploadStartActionNameUploadFinalize,
-						RequestID: result.RequestID,
-						Result: types.FileUploadFinalizeResponse{
-							TotalLen:  len(received),
-							Complete:  true,
-							Cancelled: false,
-						},
-					})).To(Succeed())
-				})
+							Expect(writeJSON(ws, &types.WebSocketResponse[types.FileUploadFinalizeResponse]{
+								Success:   true,
+								Action:    types.FileUploadStartActionNameUploadFinalize,
+								RequestID: result.RequestID,
+								Result: types.FileUploadFinalizeResponse{
+									TotalLen:  len(received),
+									Complete:  true,
+									Cancelled: false,
+								},
+							})).To(Succeed())
+						}),
+					),
+				)
 			})
 
 			It("ignore the message", func() {
-				Expect(*returnedErr).To(Succeed())
+				Expect(returnedErr).To(Succeed())
 				Expect(returnedWriter).ToNot(BeNil())
 
 				Expect(returnedWriter.Write(content)).To(BeEquivalentTo(size))
@@ -419,17 +494,17 @@ var _ = Describe("FileUpload", func() {
 })
 
 func writeJSON(ws *websocket.Conn, data interface{}) error {
-	w, err := ws.NextWriter(websocket.BinaryMessage)
+	w, err := ws.NextWriter(websocket.TextMessage)
 	if err != nil {
 		return fmt.Errorf("next writer: %w", err)
 	}
 
 	if err := json.NewEncoder(gbytes.TimeoutWriter(w, time.Second)).Encode(data); err != nil {
-		return fmt.Errorf("write json: %w", err)
+		return fmt.Errorf("write: %w", err)
 	}
 
 	if err := w.Close(); err != nil {
-		return fmt.Errorf("close writer: %w", err)
+		return fmt.Errorf("close: %w", err)
 	}
 
 	return nil
@@ -449,4 +524,33 @@ func readJSON(ws *websocket.Conn, result interface{}) error {
 	}
 
 	return nil
+}
+
+func readChunk(ws *websocket.Conn) ([]byte, error) {
+	messageType, content, err := ws.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("next reader: %w", err)
+	}
+
+	if messageType != websocket.BinaryMessage {
+		return nil, fmt.Errorf("unexpected message type: %d", messageType)
+	}
+
+	return content, nil
+}
+
+func wsHandler(predicate func(ws *websocket.Conn)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ws, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		defer func(ws *websocket.Conn) {
+			Expect(ws.Close()).To(Succeed())
+		}(ws)
+
+		predicate(ws)
+	}
 }

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/onsi/gomega/gleak"
 )
 
 const (
@@ -23,6 +24,12 @@ func TestClient(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "client")
 }
+
+var _ = BeforeEach(func() {
+	DeferCleanup(func(existing []gleak.Goroutine) {
+		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(existing))
+	}, gleak.Goroutines())
+})
 
 func Must[T interface{}](returned T, err error) T {
 	if err != nil {

--- a/types/file_upload.go
+++ b/types/file_upload.go
@@ -1,0 +1,92 @@
+package types
+
+type uploadActionForce string
+
+const (
+	FileUploadStartActionForceOverwrite uploadActionForce = "overwrite"
+	FileUploadStartActionForceMissing   uploadActionForce = "missing"
+	FileUploadStartActionForceResume    uploadActionForce = "resume"
+)
+
+const (
+	FileUploadStartActionNameUploadStart    WebSocketAction = "upload_start"
+	FileUploadStartActionNameUploadFinalize WebSocketAction = "upload_finalize"
+	FileUploadStartActionNameUploadData     WebSocketAction = "upload_data"
+	FileUploadStartActionNameUploadCancel   WebSocketAction = "upload_cancel"
+)
+
+type UploadRequestID = WebSocketRequestID
+
+type FileUploadStartAction struct {
+	RequestID UploadRequestID   `json:"request_id,omitempty"` // optional request_id
+	Action    WebSocketAction   `json:"action"`               // must be ‘upload_start’
+	Size      int               `json:"size"`                 // optional file size
+	Dirname   Base64Path        `json:"dirname"`              // the destination directory (encoded value)
+	Filename  string            `json:"filename"`             // the destination filename
+	Force     uploadActionForce `json:"force"`                // select the way conflicts are handled
+}
+
+type FileUploadStartResponse struct {
+	Success   bool            `json:"success"`
+	Action    string          `json:"action"`
+	RequestID UploadRequestID `json:"request_id"`
+	Message   string          `json:"msg"`
+	FileSize  int             `json:"file_size"`
+	ErrorCode string          `json:"error_code"`
+}
+
+type FileUploadStartActionInput struct {
+	Size     int               // optional file size
+	Dirname  Base64Path        // the destination directory (encoded value)
+	Filename string            // the destination filename
+	Force    uploadActionForce // select the way conflicts are handled
+}
+
+type FileUploadChunkResponse struct {
+	TotalLen  int  `json:"total_len"` // Target file current length
+	Complete  bool `json:"complete"`  // Will be true in a reply to FileUploadFinalizeAction or FileUploadCancelAction
+	Cancelled bool `json:"cancelled"` // Will be true in a reply FileUploadCancelAction
+}
+
+type FileUploadFinalize struct {
+	Action    WebSocketAction `json:"action"` // must be ‘upload_finalize’
+	RequestID UploadRequestID `json:"request_id,omitempty"`
+}
+
+type FileUploadCancelAction struct {
+	Action    WebSocketAction `json:"action"` // must be ‘upload_cancel’
+	RequestID UploadRequestID `json:"request_id,omitempty"`
+}
+
+type FileUploadCancelResponse struct {
+	Cancelled bool `json:"cancelled,omitempty"` // Will be true in a reply FileUploadCancelAction
+}
+
+type FileUploadFinalizeResponse struct {
+	TotalLen  int  `json:"total_len"`           // Target file current length
+	Complete  bool `json:"complete"`            // Will be true in a reply to FileUploadFinalizeAction or FileUploadCancelAction
+	Cancelled bool `json:"cancelled,omitempty"` // Will be true in a reply FileUploadCancelAction
+}
+
+type UploadTaskStatus string
+
+const (
+	UploadTaskStatusAuthorized UploadTaskStatus = "authorized"  // Upload authorization is valid, upload has not started yet
+	UploadTaskStatusInProgress UploadTaskStatus = "in_progress" // Upload in progress
+	UploadTaskStatusDone       UploadTaskStatus = "done"        // Upload done
+	UploadTaskStatusFailed     UploadTaskStatus = "failed"      // Upload failed
+	UploadTaskStatusConflict   UploadTaskStatus = "conflict"    // Destination file conflict
+	UploadTaskStatusTimeout    UploadTaskStatus = "timeout"     // Upload authorization is no longer valid
+	UploadTaskStatusCancelled  UploadTaskStatus = "cancelled"   // Upload cancelled by user
+)
+
+type UploadTask struct {
+	ID         int              `json:"id"`          // Upload id
+	Size       int              `json:"size"`        // Upload file size in bytes
+	Uploaded   int              `json:"uploaded"`    // Uploaded bytes
+	Status     UploadTaskStatus `json:"status"`      // Upload status
+	StartDate  Timestamp        `json:"start_date"`  // Upload start date
+	LastUpdate Timestamp        `json:"last_update"` // Last update of file upload object
+	UploadName string           `json:"upload_name"` // Name of the file uploaded
+	Dirname    string           `json:"dirname"`     // Upload destination directory
+}

--- a/types/file_upload.go
+++ b/types/file_upload.go
@@ -28,11 +28,22 @@ type FileUploadStartAction struct {
 
 type FileUploadStartResponse struct {
 	Success   bool            `json:"success"`
-	Action    string          `json:"action"`
+	Action    WebSocketAction `json:"action"`
 	RequestID UploadRequestID `json:"request_id"`
-	Message   string          `json:"msg"`
-	FileSize  int             `json:"file_size"`
-	ErrorCode string          `json:"error_code"`
+	Message   string          `json:"msg,omitempty"`
+	FileSize  int             `json:"file_size,omitempty"`
+	ErrorCode string          `json:"error_code,omitempty"`
+}
+
+func (r *FileUploadStartResponse) GetError() error {
+	if !r.Success {
+		return &WebSocketResponseError{
+			ErrorCode: r.ErrorCode,
+			Message:   r.Message,
+		}
+	}
+
+	return nil
 }
 
 type FileUploadStartActionInput struct {

--- a/types/web_socket.go
+++ b/types/web_socket.go
@@ -1,0 +1,35 @@
+package types
+
+import "fmt"
+
+type WebSocketAction string
+type WebSocketRequestID int64
+
+// https://dev.freebox.fr/sdk/os/#WebSocketResponse
+type WebSocketResponse[R interface{}] struct {
+	RequestID WebSocketRequestID `json:"request_id,omitempty"` // If you set a request_id in your WebSocketRequest, the same request_id will be returned in the associated response
+	Action    WebSocketAction    `json:"action,omitempty"`     // The action of the response. (It may be omitted if the request does not expect any action)
+	Success   bool               `json:"success"`              // Indicates if the request was successful
+	Result    R                  `json:"result,omitempty"`     // The result of the request. (It may be omitted if the request does not expect any result)
+	ErrorCode string             `json:"error_code"`           // In case of request error, this error_code provides information about the error. The possible error_code values are documented for each API.
+	Message   string             `json:"msg"`                  // In cas of error, provides a French error message relative to the error
+}
+
+func (r *WebSocketResponse[R]) GetError() error {
+	if r.Success {
+		return nil
+	}
+	return &WebSocketResponseError{
+		ErrorCode: r.ErrorCode,
+		Message:   r.Message,
+	}
+}
+
+type WebSocketResponseError struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"msg"`
+}
+
+func (e *WebSocketResponseError) Error() string {
+	return fmt.Sprintf("%s: %s", e.ErrorCode, e.Message)
+}

--- a/types/web_socket.go
+++ b/types/web_socket.go
@@ -2,8 +2,10 @@ package types
 
 import "fmt"
 
-type WebSocketAction string
-type WebSocketRequestID int64
+type (
+	WebSocketAction    string
+	WebSocketRequestID int64
+)
 
 // https://dev.freebox.fr/sdk/os/#WebSocketResponse
 type WebSocketResponse[R interface{}] struct {
@@ -19,6 +21,7 @@ func (r *WebSocketResponse[R]) GetError() error {
 	if r.Success {
 		return nil
 	}
+
 	return &WebSocketResponseError{
 		ErrorCode: r.ErrorCode,
 		Message:   r.Message,


### PR DESCRIPTION
This is a big change. Do you want me to split the PR in small pieces?

This PR introduce the following methods:
```go
type Client interface {
	FileUploadStart(ctx context.Context, input types.FileUploadStartActionInput) (io.WriteCloser, error)
	GetUploadTask(ctx context.Context, identifier int64) (*types.UploadTask, error)
	ListUploadTasks(ctx context.Context) ([]types.UploadTask, error)
	CancelUploadTask(ctx context.Context, identifier int64) error
	DeleteUploadTask(ctx context.Context, identifier int64) error
	CleanUploadTasks(ctx context.Context) error
}
```