### PR TITLE
chore(websockets) Adds helpers and factorize websocket and events apis

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -71,7 +71,7 @@ func (c *client) ListenEvents(ctx context.Context, events []types.EventDescripti
 		defer func() {
 			if finalErr != nil {
 				channel <- types.Event{
-					Error: fmt.Errorf("encountered error while handling the event notification: %w", err),
+					Error: fmt.Errorf("encountered error while handling the event notification: %w", finalErr),
 				}
 			}
 
@@ -82,7 +82,7 @@ func (c *client) ListenEvents(ctx context.Context, events []types.EventDescripti
 				}
 			}
 
-			if err = ws.Close(); err != nil {
+			if err := ws.Close(); err != nil {
 				channel <- types.Event{
 					Error: fmt.Errorf("closing websocket returned an error: %w", err),
 				}
@@ -100,7 +100,7 @@ func (c *client) ListenEvents(ctx context.Context, events []types.EventDescripti
 			}
 
 			if !eventPayload.Success {
-				err = fmt.Errorf("received unexpected event payload with success=%t", eventPayload.Success)
+				finalErr = fmt.Errorf("received unexpected event payload with success=%t", eventPayload.Success)
 
 				return
 			}

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -101,7 +101,7 @@ var _ = Describe("events", func() {
 			var event types.Event
 			Eventually(*returnedChannel).Should(Receive(&event))
 			Expect(event).To(Equal(types.Event{
-				Notification: types.EventNotification{
+				Notification: types.WebSocketNotification{
 					Action:  "notification",
 					Success: true,
 					Source:  "foo",
@@ -146,7 +146,7 @@ var _ = Describe("events", func() {
 				cancelContext()
 
 				_, _, err = ws.ReadMessage()
-				Expect(websocket.IsCloseError(err, websocket.CloseNormalClosure)).To(BeTrue(), "websocket should have been closed by client")
+				Expect(websocket.IsCloseError(err, websocket.CloseNormalClosure)).To(BeTrue(), fmt.Sprintf("websocket should have been closed by client, got: %v", err))
 			})
 		})
 		It("should not return an error", func() {

--- a/client/websocket_utils.go
+++ b/client/websocket_utils.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+func (c *client) webSocket(ctx context.Context, endpoint string) (*websocket.Conn, error) {
+	header := http.Header{}
+	if err := c.withSession(ctx)(&http.Request{
+		Header: header,
+	}); err != nil {
+		return nil, fmt.Errorf("get a session: %w", err)
+	}
+
+	url := *c.base
+	url.Scheme = "ws"
+
+	if strings.ToLower(c.base.Scheme) == "https" {
+		url.Scheme = "wss"
+	}
+
+	url.Path = url.Path + endpoint
+
+	ws, dialResponse, err := websocket.DefaultDialer.DialContext(ctx, url.String(), header)
+	if err != nil {
+		return nil, fmt.Errorf("dialing websocket returned a status %s: %w", dialResponse.Status, err)
+	}
+
+	return ws, nil
+}
+
+func waitWebSocketResponse[R interface{}](ctx context.Context, ws *websocket.Conn, requestID types.WebSocketRequestID, action types.WebSocketAction) (*R, error) {
+	for {
+		message, err := waitJSONResponse[types.WebSocketResponse[R]](ctx, ws)
+		if err != nil {
+			return nil, err
+		}
+
+		if (message.RequestID == requestID) && message.Action == action {
+			if err := message.GetError(); err != nil {
+				return nil, fmt.Errorf("response: %w", err)
+			}
+
+			return &message.Result, nil
+		}
+	}
+}
+
+func waitJSONResponse[T interface{}](ctx context.Context, ws *websocket.Conn) (*T, error) {
+	content, err := waitResponse(ctx, ws, websocket.TextMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	result := new(T)
+
+	if err := json.Unmarshal(content, result); err != nil {
+		var wsResponse types.WebSocketResponse[interface{}]
+		if json.Unmarshal(content, &wsResponse) == nil {
+			if err := wsResponse.GetError(); err != nil {
+				return nil, fmt.Errorf("unexpected error from server: %w", wsResponse.GetError())
+			}
+		}
+
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	return result, nil
+}
+
+func waitResponse(ctx context.Context, ws *websocket.Conn, expectedType int) ([]byte, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("cancelled: %w", ctx.Err())
+		default:
+			messageType, data, err := ws.ReadMessage()
+			if err != nil {
+				if expectedType == websocket.CloseMessage && websocket.IsUnexpectedCloseError(err) {
+					return data, nil
+				}
+
+				return nil, fmt.Errorf("read websocket message: %w", err)
+			}
+
+			if messageType == expectedType {
+				return data, nil
+			}
+			if messageType == websocket.CloseMessage {
+				return data, fmt.Errorf("websocket closed: %w", errors.New(string(data)))
+			}
+		}
+	}
+}

--- a/types/events.go
+++ b/types/events.go
@@ -1,26 +1,120 @@
 package types
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type EventDescription struct {
 	Source eventSource
 	Name   eventName
 }
 
+func (d *EventDescription) String() string {
+	return string(d.Source) + "_" + string(d.Name)
+}
+
 type Event struct {
-	Notification EventNotification
+	Notification WebSocketNotification
 	Error        error
 }
 
-type EventNotification struct {
-	Action  string          `json:"action"`
+// Deprecated: use WebSocketNotification instead.
+type EventNotification = WebSocketNotification
+
+type WebSocketNotification struct {
+	Action  WebSocketAction `json:"action"`
 	Success bool            `json:"success"`
 	Source  eventSource     `json:"source"`
 	Event   eventName       `json:"event"`
 	Result  json.RawMessage `json:"result"`
 }
 
+func (n *WebSocketNotification) VmStateChange() (*VmStateChange, error) {
+	if !n.Action.Is(&EventDescription{
+		Source: EventSourceVM,
+		Name:   EventStateChanged,
+	}) {
+		return nil, fmt.Errorf("unexpected action: %s", n.Action)
+	}
+
+	result := new(VmStateChange)
+	if err := json.Unmarshal(n.Result, result); err != nil {
+		return nil, fmt.Errorf("unmarshal VmStateChange: %w", err)
+	}
+
+	return result, nil
+}
+
+func (n *WebSocketNotification) VmDiskTask() (*VmDiskTask, error) {
+	if !n.Action.Is(&EventDescription{
+		Source: EventSourceVMDisk,
+		Name:   EventDiskTaskDone,
+	}) {
+		return nil, fmt.Errorf("unexpected action: %s", n.Action)
+	}
+
+	result := new(VmDiskTask)
+	if err := json.Unmarshal(n.Result, result); err != nil {
+		return nil, fmt.Errorf("unmarshal VmDiskTask: %w", err)
+	}
+
+	return result, nil
+}
+
+func (n *WebSocketNotification) LanHost() (*LanHost, error) {
+	if !n.Action.Is(&EventDescription{
+		Source: EventSourceLANHost,
+		Name:   EventHostL3AddrReachable,
+	}) && !n.Action.Is(&EventDescription{
+		Source: EventSourceLANHost,
+		Name:   EventHostL3AddrUnreachable,
+	}) {
+		return nil, fmt.Errorf("unexpected action: %s", n.Action)
+	}
+
+	result := new(LanHost)
+	if err := json.Unmarshal(n.Result, result); err != nil {
+		return nil, fmt.Errorf("unmarshal LanHost: %w", err)
+	}
+
+	return result, nil
+}
+
 type (
 	eventSource string
 	eventName   string
+	eventAction string
+)
+
+type (
+	VmStateChange struct {
+		ID     int           `json:"id"`     // VM id.
+		Status machineStatus `json:"status"` // New VM.status.
+	}
+
+	VmDiskTask struct {
+		ID    int                        `json:"id"`              // Task id.
+		Type  virtualMachineDiskTaskType `json:"type"`            // Type of disk operation.
+		Done  bool                       `json:"done"`            // Is task done
+		Error string                     `json:"error,omitempty"` // Error message if task failed.
+	}
+
+	LanHost struct {
+		ID                int                   `json:"id"`                  // Host id (unique on this interface).
+		PrimaryName       string                `json:"primary_name"`        // Host primary name (chosen from the list of available names, or manually set by user).
+		HostType          hostType              `json:"host_type"`           // When possible, the Freebox will try to guess the host_type, but you can manually override this to the correct value.
+		PrimaryNameManual bool                  `json:"primary_name_manual"` // If true the primary name has been set manually.
+		L2Ident           []L2Ident             `json:"l2ident"`             // Layer 2 network id and its type
+		VendorName        string                `json:"vendor_name"`         // Host vendor name (from the mac address)
+		Persistent        bool                  `json:"persistent"`          // If true the host is always shown even if it has not been active since the Freebox startup
+		Reachable         bool                  `json:"reachable"`           // If true the host can receive traffic from the Freebox
+		LastTimeReachable Timestamp             `json:"last_time_reachable"` // Last time the host was reached
+		Active            bool                  `json:"active"`              // If true the host sends traffic to the Freebox
+		LastActivity      Timestamp             `json:"last_activity"`       // Last time the host sent traffic
+		FirstActivity     Timestamp             `json:"first_activity"`      // First time the host sent traffic, or 0 (Unix Epoch) if it wasn’t seen before this field was added.
+		Names             []HostName            `json:"names"`               // List of names associated with this host
+		L3Connectivities  []L3Connectivity      `json:"l3connectivities"`    // List of available layer 3 network connections
+		NetworkControl    LanHostNetworkControl `json:"network_control"`     // If device is associated with a profile, contains profile summary.
+	}
 )

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -1,0 +1,187 @@
+package types_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("Events", func() {
+	Describe("EventDescription", func() {
+		Describe("String", func() {
+			It("should return the event description", func() {
+				Expect((&types.EventDescription{
+					Source: types.EventSourceVM,
+					Name:   types.EventStateChanged,
+				}).String()).To(Equal("vm_state_changed"))
+			})
+		})
+	})
+
+	Describe("WebSocketNotification", func() {
+		Describe("VmStateChange", func() {
+			Context("when the action is not a VmStateChange", func() {
+				It("should return an error", func() {
+					_, err := (&types.WebSocketNotification{
+						Action:  "unexpected_action",
+						Success: true,
+						Source:  types.EventSourceVM,
+						Event:   types.EventStateChanged,
+						Result:  json.RawMessage(`{}`),
+					}).VmStateChange()
+
+					Expect(err).To(MatchError("unexpected action: unexpected_action"))
+				})
+			})
+
+			Context("when the result cannot be unmarshalled", func() {
+				It("should return an error", func() {
+					_, err := (&types.WebSocketNotification{
+						Action:  "vm_state_changed",
+						Success: true,
+						Source:  types.EventSourceVM,
+						Event:   types.EventStateChanged,
+						Result:  json.RawMessage(`{`),
+					}).VmStateChange()
+
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("when the action is a VmStateChange", func() {
+				It("should return the VmStateChange", func() {
+					eventResult, err := json.Marshal(&types.VmStateChange{
+						ID: 123,
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					notification := &types.WebSocketNotification{
+						Action:  "vm_state_changed",
+						Success: true,
+						Source:  types.EventSourceVM,
+						Event:   types.EventStateChanged,
+						Result:  json.RawMessage(eventResult),
+					}
+					Expect(notification.VmStateChange()).To(Equal(&types.VmStateChange{
+						ID: 123,
+					}))
+					_, err = notification.VmDiskTask()
+					Expect(err).To(MatchError("unexpected action: vm_state_changed"))
+					_, err = notification.LanHost()
+					Expect(err).To(MatchError("unexpected action: vm_state_changed"))
+				})
+			})
+		})
+
+		Describe("VmDiskTask", func() {
+			Context("when the action is not a VmDiskTask", func() {
+				It("should return an error", func() {
+					_, err := (&types.WebSocketNotification{
+						Action:  "unexpected_action",
+						Success: true,
+						Source:  types.EventSourceVMDisk,
+						Event:   types.EventDiskTaskDone,
+						Result:  json.RawMessage(`{}`),
+					}).VmDiskTask()
+
+					Expect(err).To(MatchError("unexpected action: unexpected_action"))
+				})
+			})
+
+			Context("when the result cannot be unmarshalled", func() {
+				It("should return an error", func() {
+					_, err := (&types.WebSocketNotification{
+						Action:  "vm_disk_task_done",
+						Success: true,
+						Source:  types.EventSourceVMDisk,
+						Event:   types.EventDiskTaskDone,
+						Result:  json.RawMessage(`{`),
+					}).VmDiskTask()
+
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("when the action is a VmDiskTask", func() {
+				It("should return the VmDiskTask", func() {
+					eventResult, err := json.Marshal(&types.VmDiskTask{
+						ID: 123,
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					notification := &types.WebSocketNotification{
+						Action:  "vm_disk_task_done",
+						Success: true,
+						Source:  types.EventSourceVMDisk,
+						Event:   types.EventDiskTaskDone,
+						Result:  json.RawMessage(eventResult),
+					}
+					Expect(notification.VmDiskTask()).To(Equal(&types.VmDiskTask{
+						ID: 123,
+					}))
+					_, err = notification.VmStateChange()
+					Expect(err).To(MatchError("unexpected action: vm_disk_task_done"))
+					_, err = notification.LanHost()
+					Expect(err).To(MatchError("unexpected action: vm_disk_task_done"))
+				})
+			})
+		})
+
+		Describe("LanHost", func() {
+			Context("when the action is not a LanHost", func() {
+				It("should return an error", func() {
+					_, err := (&types.WebSocketNotification{
+						Action:  "unexpected_action",
+						Success: true,
+						Source:  types.EventSourceLANHost,
+						Event:   types.EventHostL3AddrReachable,
+						Result:  json.RawMessage(`{}`),
+					}).LanHost()
+
+					Expect(err).To(MatchError("unexpected action: unexpected_action"))
+				})
+			})
+
+			Context("when the result cannot be unmarshalled", func() {
+				It("should return an error", func() {
+					_, err := (&types.WebSocketNotification{
+						Action:  "lan_host_l3addr_reachable",
+						Success: true,
+						Source:  types.EventSourceLANHost,
+						Event:   types.EventHostL3AddrReachable,
+						Result:  json.RawMessage(`{`),
+					}).LanHost()
+
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("when the action is a LanHost", func() {
+				It("should return the LanHost", func() {
+					eventResult, err := json.Marshal(&types.LanHost{
+						ID: 123,
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					notification := &types.WebSocketNotification{
+						Action:  "lan_host_l3addr_reachable",
+						Success: true,
+						Source:  types.EventSourceLANHost,
+						Event:   types.EventHostL3AddrReachable,
+						Result:  json.RawMessage(eventResult),
+					}
+					Expect(notification.LanHost()).To(Equal(&types.LanHost{
+						ID: 123,
+					}))
+					_, err = notification.VmDiskTask()
+					Expect(err).To(MatchError("unexpected action: lan_host_l3addr_reachable"))
+					_, err = notification.VmStateChange()
+					Expect(err).To(MatchError("unexpected action: lan_host_l3addr_reachable"))
+				})
+			})
+		})
+	})
+})

--- a/types/lan_browser.go
+++ b/types/lan_browser.go
@@ -95,3 +95,9 @@ type L3Connectivity struct {
 	LastTimeReachable Timestamp `json:"last_time_reachable"`
 	Type              af        `json:"af"`
 }
+
+type LanHostNetworkControl struct {
+	ProfileID   int    `json:"profile_id"`   // Id of profile this device is associated with.
+	Name        string `json:"name"`         // Name of profile this device is associated with.
+	CurrentMode string `json:"current_mode"` // Mode described in Network Control Object
+}

--- a/types/web_socket.go
+++ b/types/web_socket.go
@@ -14,7 +14,7 @@ type WebSocketResponse[R interface{}] struct {
 	Success   bool               `json:"success"`              // Indicates if the request was successful
 	Result    R                  `json:"result,omitempty"`     // The result of the request. (It may be omitted if the request does not expect any result)
 	ErrorCode string             `json:"error_code"`           // In case of request error, this error_code provides information about the error. The possible error_code values are documented for each API.
-	Message   string             `json:"msg"`                  // In cas of error, provides a French error message relative to the error
+	Message   string             `json:"msg"`                  // In case of error, provides a French error message relative to the error
 }
 
 func (r *WebSocketResponse[R]) GetError() error {
@@ -35,4 +35,8 @@ type WebSocketResponseError struct {
 
 func (e *WebSocketResponseError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrorCode, e.Message)
+}
+
+func (a WebSocketAction) Is(desc *EventDescription) bool {
+	return string(a) == desc.String()
 }

--- a/types/web_socket_test.go
+++ b/types/web_socket_test.go
@@ -1,0 +1,54 @@
+package types_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("WebSocket", func() {
+	Describe("WebSocketAction", func() {
+		Describe("Is", func() {
+			Context("when the action is the same", func() {
+				It("should return true", func() {
+					Expect(types.WebSocketAction("lan_host_l3addr_reachable").Is(&types.EventDescription{
+						Source: types.EventSourceLANHost,
+						Name:   types.EventHostL3AddrReachable,
+					})).To(BeTrue())
+				})
+			})
+
+			Context("when the action is different", func() {
+				It("should return false", func() {
+					Expect(types.WebSocketAction("lan_host_l3addr_reachable").Is(&types.EventDescription{
+						Source: types.EventSourceLANHost,
+						Name:   types.EventHostL3AddrUnreachable,
+					})).To(BeFalse())
+				})
+			})
+		})
+	})
+
+	Describe("WebSocketResponse", func() {
+		Describe("GetError", func() {
+			Context("when the response is a success", func() {
+				It("should return nil", func() {
+					Expect((&types.WebSocketResponse[interface{}]{
+						Success: true,
+					}).GetError()).To(BeNil())
+				})
+			})
+
+			Context("when the response is a failure", func() {
+				It("should return the error", func() {
+					Expect((&types.WebSocketResponse[interface{}]{
+						Success: false,
+						ErrorCode: `error_code`,
+						Message: `un message d'erreur`,
+					}).GetError()).To(MatchError(And(ContainSubstring(`error_code`), ContainSubstring(`un message d'erreur`))))
+				})
+			})
+		})
+	})
+})

--- a/types/web_socket_test.go
+++ b/types/web_socket_test.go
@@ -43,9 +43,9 @@ var _ = Describe("WebSocket", func() {
 			Context("when the response is a failure", func() {
 				It("should return the error", func() {
 					Expect((&types.WebSocketResponse[interface{}]{
-						Success: false,
+						Success:   false,
 						ErrorCode: `error_code`,
-						Message: `un message d'erreur`,
+						Message:   `un message d'erreur`,
 					}).GetError()).To(MatchError(And(ContainSubstring(`error_code`), ContainSubstring(`un message d'erreur`))))
 				})
 			})


### PR DESCRIPTION
The goal of this PR is to make websocket calls more robust.
Introduce helpers on type and its tests.
Introduce websocket factory and wait* function.