### PR TITLE
fix(types/lan)

### DIFF
--- a/client/dhcp_static_test.go
+++ b/client/dhcp_static_test.go
@@ -86,7 +86,7 @@ var _ = Describe("DHCPStatic", func() {
 										ID:                "ether-7e:ec:37:cd:5b:6a",
 										LastTimeReachable: types.Timestamp{Time: time.Unix(1682578724, 0)},
 										PrimaryNameManual: true,
-										L3Connectivities: []types.L3Connectivity{
+										L3Connectivities: []types.LanHostL3Connectivity{
 											{
 												Address:           IPAddress,
 												Active:            true,
@@ -263,7 +263,7 @@ var _ = Describe("DHCPStatic", func() {
 									LastActivity:      types.Timestamp{Time: time.Unix(1682578724, 0)},
 									PrimaryName:       "testing",
 									DefaultName:       "testing",
-									L3Connectivities: []types.L3Connectivity{
+									L3Connectivities: []types.LanHostL3Connectivity{
 										{
 											Address:           IPAddress,
 											Active:            true,
@@ -410,7 +410,7 @@ var _ = Describe("DHCPStatic", func() {
 										Source: "dhcp",
 									},
 								},
-								L3Connectivities: []types.L3Connectivity{
+								L3Connectivities: []types.LanHostL3Connectivity{
 									{
 										Address:           IPAddress,
 										Active:            true,
@@ -506,7 +506,7 @@ var _ = Describe("DHCPStatic", func() {
 										Source: "dhcp",
 									},
 								},
-								L3Connectivities: []types.L3Connectivity{
+								L3Connectivities: []types.LanHostL3Connectivity{
 									{
 										Address:           IPAddress,
 										Active:            true,

--- a/client/dhcp_static_test.go
+++ b/client/dhcp_static_test.go
@@ -148,6 +148,7 @@ var _ = Describe("DHCPStatic", func() {
 								"LastTimeReachable": gstruct.MatchAllFields(gstruct.Fields{
 									"Time": BeTemporally("==", time.Unix(1682578724, 0)),
 								}),
+								"Model": BeEmpty(),
 							})),
 							"DefaultName": Equal("testing"),
 							"FirstActivity": gstruct.MatchAllFields(gstruct.Fields{
@@ -157,8 +158,10 @@ var _ = Describe("DHCPStatic", func() {
 							"LastActivity": gstruct.MatchAllFields(gstruct.Fields{
 								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
 							}),
-							"PrimaryName": Equal("testing"),
+							"PrimaryName":    Equal("testing"),
 							"NetworkControl": BeNil(),
+							"Model":          BeEmpty(),
+							"AccessPoint":    BeNil(),
 						}),
 					})),
 				)
@@ -324,8 +327,11 @@ var _ = Describe("DHCPStatic", func() {
 							"LastTimeReachable": gstruct.MatchAllFields(gstruct.Fields{
 								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
 							}),
+							"Model": BeEmpty(),
 						})),
+						"Model":          BeEmpty(),
 						"NetworkControl": BeNil(),
+						"AccessPoint":    BeNil(),
 					}),
 				}))
 			})

--- a/client/dhcp_static_test.go
+++ b/client/dhcp_static_test.go
@@ -158,6 +158,7 @@ var _ = Describe("DHCPStatic", func() {
 								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
 							}),
 							"PrimaryName": Equal("testing"),
+							"NetworkControl": BeNil(),
 						}),
 					})),
 				)
@@ -324,6 +325,7 @@ var _ = Describe("DHCPStatic", func() {
 								"Time": BeTemporally("==", time.Unix(1682578724, 0)),
 							}),
 						})),
+						"NetworkControl": BeNil(),
 					}),
 				}))
 			})

--- a/client/lan_browser_test.go
+++ b/client/lan_browser_test.go
@@ -245,7 +245,7 @@ var _ = Describe("lan browser", func() {
 						Names: []types.HostName{
 							{Name: "test", Source: "dhcp"},
 						},
-						L3Connectivities: []types.L3Connectivity{
+						L3Connectivities: []types.LanHostL3Connectivity{
 							{
 								Address:   "192.168.1.254",
 								Active:    false,
@@ -397,7 +397,7 @@ var _ = Describe("lan browser", func() {
 					Names: []types.HostName{
 						{Name: "test", Source: "dhcp"},
 					},
-					L3Connectivities: []types.L3Connectivity{
+					L3Connectivities: []types.LanHostL3Connectivity{
 						{
 							Address:   "192.168.1.254",
 							Active:    false,

--- a/client/port_forwarding_test.go
+++ b/client/port_forwarding_test.go
@@ -115,9 +115,9 @@ var _ = Describe("port forwarding", func() {
 				Expect(*returnedRules).To(HaveLen(1))
 				Expect((*returnedRules)[0]).To(MatchFields(IgnoreExtras, Fields{
 					"Hostname": Equal("testing"),
-					"Host": MatchFields(IgnoreExtras, Fields{
+					"Host": PointTo(MatchFields(IgnoreExtras, Fields{
 						"LastActivity": Equal(types.Timestamp{Time: time.Unix(1682579132, 0).UTC()}),
-					}),
+					})),
 					"PortForwardingRulePayload": MatchFields(IgnoreExtras, Fields{
 						"LanPort":    Equal(int64(80)),
 						"IPProtocol": Equal(types.TCP),
@@ -251,9 +251,9 @@ var _ = Describe("port forwarding", func() {
 				Expect(*returnedErr).To(BeNil())
 				Expect(*returnedRule).To(MatchFields(IgnoreExtras, Fields{
 					"Hostname": Equal("testing"),
-					"Host": MatchFields(IgnoreExtras, Fields{
+					"Host": PointTo(MatchFields(IgnoreExtras, Fields{
 						"LastActivity": Equal(types.Timestamp{Time: time.Unix(1682579132, 0).UTC()}),
-					}),
+					})),
 					"ID": Equal(int64(5)),
 					"PortForwardingRulePayload": MatchFields(IgnoreExtras, Fields{
 						"LanPort":    Equal(int64(80)),
@@ -406,9 +406,9 @@ var _ = Describe("port forwarding", func() {
 				Expect(*returnedErr).To(BeNil())
 				Expect(*returnedRule).To(MatchFields(IgnoreExtras, Fields{
 					"Hostname": Equal("testing"),
-					"Host": MatchFields(IgnoreExtras, Fields{
+					"Host": PointTo(MatchFields(IgnoreExtras, Fields{
 						"LastActivity": Equal(types.Timestamp{Time: time.Unix(1682579132, 0).UTC()}),
-					}),
+					})),
 					"ID":    Equal(int64(5)),
 					"Valid": Equal(true),
 					"PortForwardingRulePayload": MatchFields(IgnoreExtras, Fields{
@@ -589,9 +589,9 @@ var _ = Describe("port forwarding", func() {
 				Expect(*returnedErr).To(BeNil())
 				Expect(*returnedRule).To(MatchFields(IgnoreExtras, Fields{
 					"Hostname": Equal("testing"),
-					"Host": MatchFields(IgnoreExtras, Fields{
+					"Host": PointTo(MatchFields(IgnoreExtras, Fields{
 						"LastActivity": Equal(types.Timestamp{Time: time.Unix(1682579132, 0).UTC()}),
-					}),
+					})),
 					"ID":    Equal(int64(5)),
 					"Valid": Equal(true),
 					"PortForwardingRulePayload": MatchFields(IgnoreExtras, Fields{

--- a/types/events.go
+++ b/types/events.go
@@ -101,20 +101,20 @@ type (
 	}
 
 	LanHost struct {
-		ID                int                   `json:"id"`                  // Host id (unique on this interface).
-		PrimaryName       string                `json:"primary_name"`        // Host primary name (chosen from the list of available names, or manually set by user).
-		HostType          hostType              `json:"host_type"`           // When possible, the Freebox will try to guess the host_type, but you can manually override this to the correct value.
-		PrimaryNameManual bool                  `json:"primary_name_manual"` // If true the primary name has been set manually.
-		L2Ident           []L2Ident             `json:"l2ident"`             // Layer 2 network id and its type
-		VendorName        string                `json:"vendor_name"`         // Host vendor name (from the mac address)
-		Persistent        bool                  `json:"persistent"`          // If true the host is always shown even if it has not been active since the Freebox startup
-		Reachable         bool                  `json:"reachable"`           // If true the host can receive traffic from the Freebox
-		LastTimeReachable Timestamp             `json:"last_time_reachable"` // Last time the host was reached
-		Active            bool                  `json:"active"`              // If true the host sends traffic to the Freebox
-		LastActivity      Timestamp             `json:"last_activity"`       // Last time the host sent traffic
-		FirstActivity     Timestamp             `json:"first_activity"`      // First time the host sent traffic, or 0 (Unix Epoch) if it wasn’t seen before this field was added.
-		Names             []HostName            `json:"names"`               // List of names associated with this host
-		L3Connectivities  []L3Connectivity      `json:"l3connectivities"`    // List of available layer 3 network connections
-		NetworkControl    LanHostNetworkControl `json:"network_control"`     // If device is associated with a profile, contains profile summary.
+		ID                int                     `json:"id"`                  // Host id (unique on this interface).
+		PrimaryName       string                  `json:"primary_name"`        // Host primary name (chosen from the list of available names, or manually set by user).
+		HostType          hostType                `json:"host_type"`           // When possible, the Freebox will try to guess the host_type, but you can manually override this to the correct value.
+		PrimaryNameManual bool                    `json:"primary_name_manual"` // If true the primary name has been set manually.
+		L2Ident           []L2Ident               `json:"l2ident"`             // Layer 2 network id and its type
+		VendorName        string                  `json:"vendor_name"`         // Host vendor name (from the mac address)
+		Persistent        bool                    `json:"persistent"`          // If true the host is always shown even if it has not been active since the Freebox startup
+		Reachable         bool                    `json:"reachable"`           // If true the host can receive traffic from the Freebox
+		LastTimeReachable Timestamp               `json:"last_time_reachable"` // Last time the host was reached
+		Active            bool                    `json:"active"`              // If true the host sends traffic to the Freebox
+		LastActivity      Timestamp               `json:"last_activity"`       // Last time the host sent traffic
+		FirstActivity     Timestamp               `json:"first_activity"`      // First time the host sent traffic, or 0 (Unix Epoch) if it wasn’t seen before this field was added.
+		Names             []HostName              `json:"names"`               // List of names associated with this host
+		L3Connectivities  []LanHostL3Connectivity `json:"l3connectivities"`    // List of available layer 3 network connections
+		NetworkControl    LanHostNetworkControl   `json:"network_control"`     // If device is associated with a profile, contains profile summary.
 	}
 )

--- a/types/file_upload.go
+++ b/types/file_upload.go
@@ -60,13 +60,14 @@ type FileUploadChunkResponse struct {
 }
 
 type FileUploadFinalize struct {
-	Action    WebSocketAction `json:"action"` // must be ‘upload_finalize’
-	RequestID UploadRequestID `json:"request_id,omitempty"`
+	Action    WebSocketAction `json:"action"`               // must be ‘upload_finalize’
+	RequestID UploadRequestID `json:"request_id,omitempty"` // optional request_id
 }
 
 type FileUploadCancelAction struct {
-	Action    WebSocketAction `json:"action"` // must be ‘upload_cancel’
-	RequestID UploadRequestID `json:"request_id,omitempty"`
+	Action    WebSocketAction `json:"action"`               // must be ‘upload_cancel’
+	RequestID UploadRequestID `json:"request_id,omitempty"` // optional request_id
+
 }
 
 type FileUploadCancelResponse struct {

--- a/types/lan_browser.go
+++ b/types/lan_browser.go
@@ -15,86 +15,140 @@ const (
 type hostType = string
 
 const (
-	Workstation      hostType = "workstation"
-	Laptop           hostType = "laptop"
-	Smartphone       hostType = "smartphone"
-	Tablet           hostType = "tablet"
-	Printer          hostType = "printer"
-	VGConsole        hostType = "vg_console"
-	Television       hostType = "television"
-	NAS              hostType = "nas"
-	IPCamera         hostType = "ip_camera"
-	IPPhone          hostType = "ip_phone"
-	FreeboxPlayer    hostType = "freebox_player"
-	FreeboxHD        hostType = "freebox_hd"
-	FreeboxCrystal   hostType = "freebox_crystal"
-	FreeboxMini      hostType = "freebox_mini"
-	FreeboxDelta     hostType = "freebox_delta"
-	FreeboxOne       hostType = "freebox_one"
-	FreeboxWIFI      hostType = "freebox_wifi"
-	FreboxPop        hostType = "freebox_pop"
-	NetworkingDevice hostType = "networking_device"
-	MultimediaDevice hostType = "multimedia_device"
-	Car              hostType = "car"
-	Other            hostType = "other"
+	Workstation      hostType = "workstation"       // Workstation
+	Laptop           hostType = "laptop"            // Laptop
+	Smartphone       hostType = "smartphone"        // Smartphone
+	Tablet           hostType = "tablet"            // Tablet
+	Printer          hostType = "printer"           // Printer
+	VGConsole        hostType = "vg_console"        // Video game console
+	Television       hostType = "television"        // Televison
+	NAS              hostType = "nas"               // Network-attached storage
+	IPCamera         hostType = "ip_camera"         // IP camera
+	IPPhone          hostType = "ip_phone"          // IP phone
+	FreeboxPlayer    hostType = "freebox_player"    // Freebox Player
+	FreeboxHD        hostType = "freebox_hd"        // Freebox HD
+	FreeboxCrystal   hostType = "freebox_crystal"   // Freebox Crystal
+	FreeboxMini      hostType = "freebox_mini"      // Freebox Mini
+	FreeboxDelta     hostType = "freebox_delta"     // Freebox Delta
+	FreeboxOne       hostType = "freebox_one"       // Freebox One
+	FreeboxWIFI      hostType = "freebox_wifi"      // Freebox WIFI
+	FreboxPop        hostType = "freebox_pop"       // Frebox Pop
+	NetworkingDevice hostType = "networking_device" // Networking device
+	MultimediaDevice hostType = "multimedia_device" // Multimedia device
+	Car              hostType = "car"               // Connected car
+	Watch            hostType = "watch"             // Smartwatch
+	Light            hostType = "light"             // Light
+	Outlet           hostType = "outlet"            // Connected outlet
+	Appliances       hostType = "appliances"        // Household appliances
+	Thermostat       hostType = "thermostat"        // Thermostat
+	Shutter          hostType = "shutter"           // Electric shutter
+	Other            hostType = "other"             // Other
 )
 
 type LanInterfaceHost struct {
-	Active            bool                   `json:"active"`
-	Persistent        bool                   `json:"persistent"`
-	Reachable         bool                   `json:"reachable"`
-	PrimaryNameManual bool                   `json:"primary_name_manual"`
-	VendorName        string                 `json:"vendor_name"`
-	Type              hostType               `json:"host_type"`
-	Interface         string                 `json:"interface"`
-	ID                string                 `json:"id"`
-	LastTimeReachable Timestamp              `json:"last_time_reachable"`
-	FirstActivity     Timestamp              `json:"first_activity"`
-	LastActivity      Timestamp              `json:"last_activity"`
-	PrimaryName       string                 `json:"primary_name"`
-	DefaultName       string                 `json:"default_name"`
-	L2Ident           L2Ident                `json:"l2ident"`
-	Names             []HostName             `json:"names"`
-	L3Connectivities  []L3Connectivity       `json:"l3connectivities"`
-	NetworkControl    *LanHostNetworkControl `json:"network_control"`
+	Active            bool                   `json:"active"`              // If true the host sends traffic to the Freebox
+	Persistent        bool                   `json:"persistent"`          // If true the host is always shown even if it has not been active since the Freebox startup
+	Reachable         bool                   `json:"reachable"`           // If true the host can receive traffic from the Freebox
+	PrimaryNameManual bool                   `json:"primary_name_manual"` // If true the primary name has been set manually
+	VendorName        string                 `json:"vendor_name"`         // Host vendor name (from the mac address)
+	Type              hostType               `json:"host_type"`           // When possible, the Freebox will try to guess the host_type, but you can manually override this to the correct value
+	ID                string                 `json:"id"`                  // Host id (unique on this interface)
+	LastTimeReachable Timestamp              `json:"last_time_reachable"` // Last time the host was reached
+	FirstActivity     Timestamp              `json:"first_activity"`      // First time the host sent traffic, or 0 (Unix Epoch) if it wasn’t seen before this field was added.
+	LastActivity      Timestamp              `json:"last_activity"`       // Last time the host sent traffic
+	PrimaryName       string                 `json:"primary_name"`        // Host primary name (chosen from the list of available names, or manually set by user)
+	L2Ident           L2Ident                `json:"l2ident"`             // Layer 2 network id and its type
+	Names             []HostName             `json:"names"`               // List of available names, and their source
+	L3Connectivities  []L3Connectivity       `json:"l3connectivities"`    // List of available layer 3 network connections
+	NetworkControl    *LanHostNetworkControl `json:"network_control"`     // If device is associated with a profile, contains profile summary.
+
+	// Undocumented fields
+
+	AccessPoint *LanHostAccessPoint `json:"access_point"`
+	DefaultName string              `json:"default_name"`
+	Interface   string              `json:"interface"`
+	Model       string              `json:"model"`
 }
 
+type LanHostAccessPoint struct {
+	RXBytes          int64                              `json:"rx_bytes"`
+	TXBytes          int64                              `json:"tx_bytes"`
+	RXRate           int64                              `json:"rx_rate"`
+	TXRate           int64                              `json:"tx_rate"`
+	UID              string                             `json:"uid"`
+	ConnectivityType LanHostAccessPointConnectivityType `json:"connectivity_type"`
+	Type             string                             `json:"type"`
+	MacAddress       string                             `json:"mac"`
+
+	WifiInformation     *LanHostAccessPointWifiInformation     `json:"wifi_information"`
+	EthernetInformation *LanHostAccessPointEthernetInformation `json:"ethernet_information"`
+}
+
+type LanHostAccessPointWifiInformation struct {
+	Band            string `json:"band"`
+	SessionDuration int64  `json:"sess_duration"`
+	PhyRXRate       int64  `json:"phy_rx_rate"`
+	SSID            string `json:"ssid"`
+	Standard        string `json:"standard"`
+	BSSID           string `json:"bssid"`
+	PhyTXRate       int64  `json:"phy_tx_rate"`
+	Signal          int64  `json:"signal"`
+}
+
+type LanHostAccessPointEthernetInformation struct {
+	Duplex       string `json:"duplex"`
+	Speed        int64  `json:"speed"`
+	MaxPortSpeed int64  `json:"max_port_speed"`
+	Link         string `json:"link"`
+}
+
+type LanHostAccessPointConnectivityType = string
+
+const (
+	WifiLanHostAccessPointConnectivityType     = "wifi"
+	EthernetLanHostAccessPointConnectivityType = "ethernet"
+)
+
 type HostName struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
+	Name   string `json:"name"`   // Host name
+	Source string `json:"source"` // source of the name
 }
 
 type l2IdentType = string
 
 const (
-	DHCP       l2IdentType = "dhcp"
-	NetBios    l2IdentType = "netbios"
-	MDNS       l2IdentType = "mdns"
-	MDNSSRV    l2IdentType = "mdns_srv"
-	UPNP       l2IdentType = "upnp"
-	WSD        l2IdentType = "wsd"
-	MacAddress l2IdentType = "mac_address"
+	DHCP    l2IdentType = "dhcp"     // DHCP
+	NetBios l2IdentType = "netbios"  // Netbios
+	MDNS    l2IdentType = "mdns"     // mDNS hostname
+	MDNSSRV l2IdentType = "mdns_srv" // mDNS service
+	UPNP    l2IdentType = "upnp"     // UPnP
+	WSD     l2IdentType = "wsd"      // WS-Discovery
+
+	// Undocumented fields
+
+	MacAddress l2IdentType = "mac_address" // MAC
 )
 
 type L2Ident struct {
-	ID   string      `json:"id"`
-	Type l2IdentType `json:"type"`
+	ID   string      `json:"id"`   // Layer 2 id
+	Type l2IdentType `json:"type"` // Type of layer 2 address
 }
 
 type af = string
 
 const (
-	IPV4 af = "ipv4"
-	IPV6 af = "ipv6"
+	IPV4 af = "ipv4" // IPv4 address family
+	IPV6 af = "ipv6" // IPv6 address family
 )
 
 type L3Connectivity struct {
-	Address           string    `json:"addr"`
-	Active            bool      `json:"active"`
-	Reachable         bool      `json:"reachable"`
-	LastActivity      Timestamp `json:"last_activity"`
-	LastTimeReachable Timestamp `json:"last_time_reachable"`
-	Type              af        `json:"af"`
+	Address           string    `json:"addr"`                // Layer 3 address
+	Active            bool      `json:"active"`              // is the connection active
+	Reachable         bool      `json:"reachable"`           // is the connection reachable
+	LastActivity      Timestamp `json:"last_activity"`       // last activity timestamp
+	LastTimeReachable Timestamp `json:"last_time_reachable"` // last reachable timestamp
+	Type              af        `json:"af"`                  // address family
+	Model             string    `json:"model"`               // device model if known
 }
 
 type LanHostNetworkControl struct {

--- a/types/lan_browser.go
+++ b/types/lan_browser.go
@@ -46,21 +46,21 @@ const (
 )
 
 type LanInterfaceHost struct {
-	Active            bool                   `json:"active"`              // If true the host sends traffic to the Freebox
-	Persistent        bool                   `json:"persistent"`          // If true the host is always shown even if it has not been active since the Freebox startup
-	Reachable         bool                   `json:"reachable"`           // If true the host can receive traffic from the Freebox
-	PrimaryNameManual bool                   `json:"primary_name_manual"` // If true the primary name has been set manually
-	VendorName        string                 `json:"vendor_name"`         // Host vendor name (from the mac address)
-	Type              hostType               `json:"host_type"`           // When possible, the Freebox will try to guess the host_type, but you can manually override this to the correct value
-	ID                string                 `json:"id"`                  // Host id (unique on this interface)
-	LastTimeReachable Timestamp              `json:"last_time_reachable"` // Last time the host was reached
-	FirstActivity     Timestamp              `json:"first_activity"`      // First time the host sent traffic, or 0 (Unix Epoch) if it wasn’t seen before this field was added.
-	LastActivity      Timestamp              `json:"last_activity"`       // Last time the host sent traffic
-	PrimaryName       string                 `json:"primary_name"`        // Host primary name (chosen from the list of available names, or manually set by user)
-	L2Ident           L2Ident                `json:"l2ident"`             // Layer 2 network id and its type
-	Names             []HostName             `json:"names"`               // List of available names, and their source
-	L3Connectivities  []L3Connectivity       `json:"l3connectivities"`    // List of available layer 3 network connections
-	NetworkControl    *LanHostNetworkControl `json:"network_control"`     // If device is associated with a profile, contains profile summary.
+	Active            bool                    `json:"active"`              // If true the host sends traffic to the Freebox
+	Persistent        bool                    `json:"persistent"`          // If true the host is always shown even if it has not been active since the Freebox startup
+	Reachable         bool                    `json:"reachable"`           // If true the host can receive traffic from the Freebox
+	PrimaryNameManual bool                    `json:"primary_name_manual"` // If true the primary name has been set manually
+	VendorName        string                  `json:"vendor_name"`         // Host vendor name (from the mac address)
+	Type              hostType                `json:"host_type"`           // When possible, the Freebox will try to guess the host_type, but you can manually override this to the correct value
+	ID                string                  `json:"id"`                  // Host id (unique on this interface)
+	LastTimeReachable Timestamp               `json:"last_time_reachable"` // Last time the host was reached
+	FirstActivity     Timestamp               `json:"first_activity"`      // First time the host sent traffic, or 0 (Unix Epoch) if it wasn’t seen before this field was added.
+	LastActivity      Timestamp               `json:"last_activity"`       // Last time the host sent traffic
+	PrimaryName       string                  `json:"primary_name"`        // Host primary name (chosen from the list of available names, or manually set by user)
+	L2Ident           L2Ident                 `json:"l2ident"`             // Layer 2 network id and its type
+	Names             []HostName              `json:"names"`               // List of available names, and their source
+	L3Connectivities  []LanHostL3Connectivity `json:"l3connectivities"`    // List of available layer 3 network connections
+	NetworkControl    *LanHostNetworkControl  `json:"network_control"`     // If device is associated with a profile, contains profile summary.
 
 	// Undocumented fields
 
@@ -134,21 +134,21 @@ type L2Ident struct {
 	Type l2IdentType `json:"type"` // Type of layer 2 address
 }
 
-type af = string
+type lanHostL3ConnectivityAF = string
 
 const (
-	IPV4 af = "ipv4" // IPv4 address family
-	IPV6 af = "ipv6" // IPv6 address family
+	IPV4 lanHostL3ConnectivityAF = "ipv4" // IPv4 address family
+	IPV6 lanHostL3ConnectivityAF = "ipv6" // IPv6 address family
 )
 
-type L3Connectivity struct {
-	Address           string    `json:"addr"`                // Layer 3 address
-	Active            bool      `json:"active"`              // is the connection active
-	Reachable         bool      `json:"reachable"`           // is the connection reachable
-	LastActivity      Timestamp `json:"last_activity"`       // last activity timestamp
-	LastTimeReachable Timestamp `json:"last_time_reachable"` // last reachable timestamp
-	Type              af        `json:"af"`                  // address family
-	Model             string    `json:"model"`               // device model if known
+type LanHostL3Connectivity struct {
+	Address           string                  `json:"addr"`                // Layer 3 address
+	Active            bool                    `json:"active"`              // is the connection active
+	Reachable         bool                    `json:"reachable"`           // is the connection reachable
+	LastActivity      Timestamp               `json:"last_activity"`       // last activity timestamp
+	LastTimeReachable Timestamp               `json:"last_time_reachable"` // last reachable timestamp
+	Type              lanHostL3ConnectivityAF `json:"af"`                  // address family
+	Model             string                  `json:"model"`               // device model if known
 }
 
 type LanHostNetworkControl struct {

--- a/types/lan_browser.go
+++ b/types/lan_browser.go
@@ -40,22 +40,23 @@ const (
 )
 
 type LanInterfaceHost struct {
-	Active            bool             `json:"active"`
-	Persistent        bool             `json:"persistent"`
-	Reachable         bool             `json:"reachable"`
-	PrimaryNameManual bool             `json:"primary_name_manual"`
-	VendorName        string           `json:"vendor_name"`
-	Type              hostType         `json:"host_type"`
-	Interface         string           `json:"interface"`
-	ID                string           `json:"id"`
-	LastTimeReachable Timestamp        `json:"last_time_reachable"`
-	FirstActivity     Timestamp        `json:"first_activity"`
-	LastActivity      Timestamp        `json:"last_activity"`
-	PrimaryName       string           `json:"primary_name"`
-	DefaultName       string           `json:"default_name"`
-	L2Ident           L2Ident          `json:"l2ident"`
-	Names             []HostName       `json:"names"`
-	L3Connectivities  []L3Connectivity `json:"l3connectivities"`
+	Active            bool                   `json:"active"`
+	Persistent        bool                   `json:"persistent"`
+	Reachable         bool                   `json:"reachable"`
+	PrimaryNameManual bool                   `json:"primary_name_manual"`
+	VendorName        string                 `json:"vendor_name"`
+	Type              hostType               `json:"host_type"`
+	Interface         string                 `json:"interface"`
+	ID                string                 `json:"id"`
+	LastTimeReachable Timestamp              `json:"last_time_reachable"`
+	FirstActivity     Timestamp              `json:"first_activity"`
+	LastActivity      Timestamp              `json:"last_activity"`
+	PrimaryName       string                 `json:"primary_name"`
+	DefaultName       string                 `json:"default_name"`
+	L2Ident           L2Ident                `json:"l2ident"`
+	Names             []HostName             `json:"names"`
+	L3Connectivities  []L3Connectivity       `json:"l3connectivities"`
+	NetworkControl    *LanHostNetworkControl `json:"network_control"`
 }
 
 type HostName struct {

--- a/types/port_forwarding.go
+++ b/types/port_forwarding.go
@@ -3,8 +3,8 @@ package types
 type ipProtocol = string
 
 const (
-	TCP ipProtocol = "tcp"
-	UDP ipProtocol = "udp"
+	TCP ipProtocol = "tcp" // TCP
+	UDP ipProtocol = "udp" // UDP
 )
 
 type PortForwardingRulePayload struct {

--- a/types/port_forwarding.go
+++ b/types/port_forwarding.go
@@ -8,20 +8,23 @@ const (
 )
 
 type PortForwardingRulePayload struct {
-	Enabled      *bool      `json:"enabled,omitempty"`
+	Enabled      *bool      `json:"enabled,omitempty"` // is forwarding enabled
 	IPProtocol   ipProtocol `json:"ip_proto,omitempty"`
-	WanPortStart int64      `json:"wan_port_start,omitempty"`
-	WanPortEnd   int64      `json:"wan_port_end,omitempty"`
-	LanIP        string     `json:"lan_ip,omitempty"`
-	LanPort      int64      `json:"lan_port,omitempty"`
-	SourceIP     string     `json:"src_ip,omitempty"`
-	Comment      string     `json:"comment,omitempty"`
+	WanPortStart int64      `json:"wan_port_start,omitempty"` // forwarding range start
+	WanPortEnd   int64      `json:"wan_port_end,omitempty"`   // forwarding range end
+	LanIP        string     `json:"lan_ip,omitempty"`         // forwarding target on LAN
+	LanPort      int64      `json:"lan_port,omitempty"`       // forwarding target start port on LAN, (last port is lan_port + wan_port_end - wan_port_start)
+	SourceIP     string     `json:"src_ip,omitempty"`         // if src_ip == 0.0.0.0 this rule will apply to any src ip otherwise it will only apply to the specified ip address
+	Comment      string     `json:"comment,omitempty"`        // comment
 }
 
 type PortForwardingRule struct {
 	PortForwardingRulePayload
-	ID       int64             `json:"id"`
-	Valid    bool              `json:"valid"`
-	Hostname string            `json:"hostname"`
-	Host     *LanInterfaceHost `json:"host"`
+	ID       int64             `json:"id"`       // forwarding id
+	Host     *LanInterfaceHost `json:"host"`     // forwarding target host information
+	Hostname string            `json:"hostname"` // forwarding target host name
+
+	// Undocumented fields
+
+	Valid bool `json:"valid"`
 }

--- a/types/port_forwarding.go
+++ b/types/port_forwarding.go
@@ -20,8 +20,8 @@ type PortForwardingRulePayload struct {
 
 type PortForwardingRule struct {
 	PortForwardingRulePayload
-	ID       int64            `json:"id"`
-	Valid    bool             `json:"valid"`
-	Hostname string           `json:"hostname"`
-	Host     LanInterfaceHost `json:"host"`
+	ID       int64             `json:"id"`
+	Valid    bool              `json:"valid"`
+	Hostname string            `json:"hostname"`
+	Host     *LanInterfaceHost `json:"host"`
 }


### PR DESCRIPTION
Retro-engineering the `PortForwardingRule` type, adding missing `host.network_control` and make `host` and `host.network_control` nullable.

Added comments on many fields.
Added undocumented fields.