### PR TITLE
fix(api/file_upload) Use types.FileUploadCancelResponse

### DIFF
--- a/client/file_upload.go
+++ b/client/file_upload.go
@@ -246,7 +246,7 @@ func (w *ChunkWriter) Close() (finalErr error) {
 			return finalErr
 		}
 
-		if _, err := waitWebSocketResponse[types.FileUploadCancelAction](ctx, w.Conn, w.RequestID, types.FileUploadStartActionNameUploadCancel); err != nil {
+		if _, err := waitWebSocketResponse[types.FileUploadCancelResponse](ctx, w.Conn, w.RequestID, types.FileUploadStartActionNameUploadCancel); err != nil {
 			finalErr = fmt.Errorf("cancel upload confirmation: %w", err)
 			return finalErr
 		}


### PR DESCRIPTION
This has no incidence since the returned value is not used, and `FileUploadCancelResponse` includes all the field of the `FileUploadCancelAction` structure. The AI agent that suggested this change did not noticed 😓 