### PR TITLE
fix: handle empty result in fromGenericResponse

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -103,6 +104,16 @@ func (c *client) do(request *http.Request, options ...HTTPOption) (response *gen
 }
 
 func (c *client) fromGenericResponse(generic *genericResponse, target interface{}) error {
+	// The Freebox API omits the "result" field entirely when the result is an
+	// empty list (e.g. GET /vm/ with no VMs). Treat a missing result as an
+	// empty value only when the target is a slice; for any other type a missing
+	// result is unexpected and should still surface as an error.
+	if len(generic.Result) == 0 {
+		if reflect.TypeOf(target).Elem().Kind() == reflect.Slice {
+			return nil
+		}
+	}
+
 	if err := json.Unmarshal(generic.Result, target); err != nil {
 		return fmt.Errorf("failed to decode response result to given target: %w", err)
 	}

--- a/client/virtual_machines_test.go
+++ b/client/virtual_machines_test.go
@@ -273,6 +273,22 @@ var _ = Describe("virtual machines", func() {
 				Expect(*returnedErr).ToNot(BeNil())
 			})
 		})
+		Context("when the server returns no result (empty list)", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vm/", version)),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true
+						}`),
+					),
+				)
+			})
+			It("should return an empty list without error", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedMachines).To(BeEmpty())
+			})
+		})
 	})
 	Context("creating a virtual machine", func() {
 		var (


### PR DESCRIPTION
The Freebox API returns a response with no 'result' key (e.g. an empty list of VMs) as {"success": true} with no result field. Previously, fromGenericResponse would call json.Unmarshal on a nil RawMessage and return an 'unexpected end of JSON input' error, making callers like ListVirtualMachines fail when the list is legitimately empty.

Treat a missing/empty result as a no-op instead of an error.