### PR TITLE
feat(api/downloads_config): add get and put download configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ At the time of this writing, generating credentials can only be done via the Fre
   - [x] Update a download task
   - [ ] Get a download log
   - [x] Add a new download task
+ - [ ] [Download Configuration API](https://dev.freebox.fr/sdk/os/download_config/) : `/downloads/config/`
+   - [x] Get the download configuration
+   - [x] Update the download configuration
+   - [ ] Update the current throttling mode
 - [x] [Upload API](https://dev.freebox.fr/sdk/os/upload/) : `/upload/*`
   - [x] Get an upload task
   - [x] List upload tasks

--- a/client/client.go
+++ b/client/client.go
@@ -83,6 +83,8 @@ type Client interface {
 	DeleteDownloadTask(ctx context.Context, identifier int64) error
 	EraseDownloadTask(ctx context.Context, identifier int64) error
 	UpdateDownloadTask(ctx context.Context, identifier int64, payload types.DownloadTaskUpdate) error
+	GetDownloadConfiguration(ctx context.Context) (types.DownloadConfiguration, error)
+	UpdateDownloadConfiguration(ctx context.Context, payload types.DownloadConfiguration) (types.DownloadConfiguration, error)
 	// uploads
 	FileUploadStart(ctx context.Context, input types.FileUploadStartActionInput) (io.WriteCloser, int64, error)
 	GetUploadTask(ctx context.Context, identifier int64) (types.UploadTask, error)

--- a/client/downloads_config.go
+++ b/client/downloads_config.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+func (c *client) GetDownloadConfiguration(ctx context.Context) (result types.DownloadConfiguration, err error) {
+	response, err := c.get(ctx, "downloads/config/", c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to GET downloads/config/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to get download configuration from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) UpdateDownloadConfiguration(ctx context.Context, payload types.DownloadConfiguration) (result types.DownloadConfiguration, err error) {
+	response, err := c.put(ctx, "downloads/config/", payload, c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to PUT downloads/config/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to get download configuration from generic response: %w", err)
+	}
+
+	return result, nil
+}

--- a/client/downloads_config_test.go
+++ b/client/downloads_config_test.go
@@ -1,0 +1,266 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/nikolalohinski/free-go/client"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("downloads config", func() {
+	var (
+		freeboxClient client.Client
+
+		server   *ghttp.Server
+		endpoint = new(string)
+
+		sessionToken = new(string)
+
+		returnedErr = new(error)
+	)
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		DeferCleanup(server.Close)
+
+		*endpoint = server.Addr()
+
+		freeboxClient = Must(client.New(*endpoint, version)).
+			WithAppID(appID).
+			WithPrivateToken(privateToken)
+
+		*sessionToken = setupLoginFlow(server)
+	})
+
+	Context("getting the download configuration", func() {
+		returnedConfig := new(types.DownloadConfiguration)
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.GetDownloadConfiguration(context.Background())
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/downloads/config/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"max_downloading_tasks": 5,
+								"download_dir": "L0Rpc3F1ZSBkdXIvVMOpbMOpY2hhcmdlbWVudHMv",
+								"watch_dir": "L0Rpc3F1ZSBkdXIvLnF1ZXVl",
+								"use_watch_dir": true,
+								"dns1": "",
+								"dns2": "",
+								"throttling": {
+									"normal": {"rx_rate": 0, "tx_rate": 0},
+									"slow": {"rx_rate": 512, "tx_rate": 42},
+									"schedule": ["slow", "normal", "normal"],
+									"mode": "normal"
+								},
+								"news": {
+									"server": "news.free.fr",
+									"port": 119,
+									"ssl": false,
+									"user": "",
+									"nthreads": 1,
+									"auto_repair": true,
+									"lazy_par2": true,
+									"auto_extract": true,
+									"erase_tmp": true
+								},
+								"bt": {
+									"max_peers": 50,
+									"stop_ratio": 150,
+									"crypto_support": "allowed",
+									"enable_dht": false,
+									"enable_pex": false,
+									"announce_timeout": 0,
+									"main_port": 0,
+									"dht_port": 0
+								},
+								"feed": {
+									"fetch_interval": 60,
+									"max_items": 0
+								},
+								"blocklist": {
+									"sources": []
+								}
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the correct download configuration", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(Equal(types.DownloadConfiguration{
+					MaxDownloadingTasks: 5,
+					DownloadDir:         "/Disque dur/Téléchargements/",
+					WatchDir:            "/Disque dur/.queue",
+					UseWatchDir:         true,
+					DNS1:                "",
+					DNS2:                "",
+					Throttling: types.DlThrottlingConfig{
+						Normal:   types.DlRate{RxRate: 0, TxRate: 0},
+						Slow:     types.DlRate{RxRate: 512, TxRate: 42},
+						Schedule: []types.DlThrottlingMode{"slow", "normal", "normal"},
+						Mode:     types.DlThrottlingModeNormal,
+					},
+					News: types.DlNewsConfig{
+						Server:      "news.free.fr",
+						Port:        119,
+						SSL:         false,
+						User:        "",
+						NThreads:    1,
+						AutoRepair:  true,
+						LazyPar2:    true,
+						AutoExtract: true,
+						EraseTmp:    true,
+					},
+					Bt: types.DlBtConfig{
+						MaxPeers:      50,
+						StopRatio:     150,
+						CryptoSupport: types.DlBtCryptoSupportAllowed,
+					},
+					Feed: types.DlFeedConfig{
+						FetchInterval: 60,
+						MaxItems:      0,
+					},
+					BlockList: types.DlBlockListConfig{
+						Sources: []string{},
+					},
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/downloads/config/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": "not-an-object"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("updating the download configuration", func() {
+		var (
+			payload = new(types.DownloadConfiguration)
+		)
+		returnedConfig := new(types.DownloadConfiguration)
+		BeforeEach(func() {
+			*payload = types.DownloadConfiguration{
+				MaxDownloadingTasks: 3,
+				DownloadDir:         "/Disque dur/Téléchargements/",
+				UseWatchDir:         false,
+			}
+		})
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.UpdateDownloadConfiguration(context.Background(), *payload)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/downloads/config/", version)),
+						ghttp.VerifyMimeType("application/json"),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"max_downloading_tasks": 3,
+								"download_dir": "L0Rpc3F1ZSBkdXIvVMOpbMOpY2hhcmdlbWVudHMv",
+								"watch_dir": "",
+								"use_watch_dir": false,
+								"dns1": "",
+								"dns2": "",
+								"throttling": {
+									"normal": {"rx_rate": 0, "tx_rate": 0},
+									"slow": {"rx_rate": 0, "tx_rate": 0},
+									"schedule": [],
+									"mode": "normal"
+								},
+								"news": {
+									"server": "",
+									"port": 0,
+									"ssl": false,
+									"user": "",
+									"nthreads": 0,
+									"auto_repair": false,
+									"lazy_par2": false,
+									"auto_extract": false,
+									"erase_tmp": false
+								},
+								"bt": {
+									"max_peers": 0,
+									"stop_ratio": 0,
+									"crypto_support": ""
+								},
+								"feed": {
+									"fetch_interval": 0,
+									"max_items": 0
+								},
+								"blocklist": {
+									"sources": null
+								}
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the updated download configuration", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(returnedConfig.MaxDownloadingTasks).To(Equal(3))
+				Expect(string(returnedConfig.DownloadDir)).To(Equal("/Disque dur/Téléchargements/"))
+				Expect(returnedConfig.UseWatchDir).To(BeFalse())
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an api error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/downloads/config/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "auth_required",
+							"msg": "not logged in"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/types/downloads_config.go
+++ b/types/downloads_config.go
@@ -1,0 +1,78 @@
+package types
+
+type DlThrottlingMode string
+
+const (
+	DlThrottlingModeNormal    DlThrottlingMode = "normal"
+	DlThrottlingModeSlow      DlThrottlingMode = "slow"
+	DlThrottlingModeHibernate DlThrottlingMode = "hibernate"
+	DlThrottlingModeSchedule  DlThrottlingMode = "schedule"
+)
+
+type DlRate struct {
+	TxRate int64 `json:"tx_rate"` // maximum transmit rate (in byte/s), 0 means no limit
+	RxRate int64 `json:"rx_rate"` // maximum receive rate (in byte/s), 0 means no limit
+}
+
+type DlThrottlingConfig struct {
+	Normal   DlRate             `json:"normal"`
+	Slow     DlRate             `json:"slow"`
+	Schedule []DlThrottlingMode `json:"schedule"` // 168-element array (24*7 week hours starting Monday midnight)
+	Mode     DlThrottlingMode   `json:"mode"`
+}
+
+type DlBtCryptoSupport string
+
+const (
+	DlBtCryptoSupportUnsupported DlBtCryptoSupport = "unsupported"
+	DlBtCryptoSupportAllowed     DlBtCryptoSupport = "allowed"
+	DlBtCryptoSupportPreferred   DlBtCryptoSupport = "preferred"
+	DlBtCryptoSupportRequired    DlBtCryptoSupport = "required"
+)
+
+type DlBtConfig struct {
+	MaxPeers        int               `json:"max_peers"`
+	StopRatio       int               `json:"stop_ratio"` // scaled by 100; 150 means 1.5x
+	CryptoSupport   DlBtCryptoSupport `json:"crypto_support"`
+	EnableDHT       bool              `json:"enable_dht"`
+	EnablePex       bool              `json:"enable_pex"`
+	AnnounceTimeout int               `json:"announce_timeout"` // seconds
+	MainPort        int               `json:"main_port"`
+	DHTPort         int               `json:"dht_port"`
+}
+
+type DlNewsConfig struct {
+	Server      string `json:"server"`
+	Port        int    `json:"port"`
+	SSL         bool   `json:"ssl"`
+	User        string `json:"user"`
+	Password    string `json:"password,omitempty"` // write-only
+	NThreads    int    `json:"nthreads"`
+	AutoRepair  bool   `json:"auto_repair"`
+	LazyPar2    bool   `json:"lazy_par2"`
+	AutoExtract bool   `json:"auto_extract"`
+	EraseTmp    bool   `json:"erase_tmp"`
+}
+
+type DlFeedConfig struct {
+	FetchInterval int `json:"fetch_interval"` // minutes
+	MaxItems      int `json:"max_items"`
+}
+
+type DlBlockListConfig struct {
+	Sources []string `json:"sources"`
+}
+
+type DownloadConfiguration struct {
+	MaxDownloadingTasks int                `json:"max_downloading_tasks"`
+	DownloadDir         Base64Path         `json:"download_dir"`
+	WatchDir            Base64Path         `json:"watch_dir"`
+	UseWatchDir         bool               `json:"use_watch_dir"`
+	Throttling          DlThrottlingConfig `json:"throttling"`
+	News                DlNewsConfig       `json:"news"`
+	Bt                  DlBtConfig         `json:"bt"`
+	Feed                DlFeedConfig       `json:"feed"`
+	BlockList           DlBlockListConfig  `json:"blocklist"`
+	DNS1                string             `json:"dns1"`
+	DNS2                string             `json:"dns2"`
+}


### PR DESCRIPTION
## Summary

- Add `GetDownloadConfiguration(ctx)` and `UpdateDownloadConfiguration(ctx, payload)` methods to the client
- Add `types.DownloadConfiguration` and related nested types (`DlThrottlingConfig`, `DlBtConfig`, `DlNewsConfig`, `DlFeedConfig`, `DlBlockListConfig`, `DlRate`, etc.)
- Add Ginkgo tests covering success, server error, and API error cases

## API

Implements the [Download Configuration API](https://dev.freebox.fr/sdk/os/download_config/):
- `GET /downloads/config/`
- `PUT /downloads/config/`

Note: `PUT /downloads/throttling` (update throttling mode) is not yet implemented and tracked in the README.