### PR TITLE
feat(api/system): add get system info

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ At the time of this writing, generating credentials can only be done via the Fre
   - [ ] Create a MAC Filter entry
   - [ ] Reset the Wi-Fi configuration
 - [ ] [System](https://dev.freebox.fr/sdk/os/system/) : `/system/*`
+  - [x] Get the current system info [UNSTABLE]
   - [ ] Reboot the Freebox
 - [ ] [AirMedia](https://dev.freebox.fr/sdk/os/airmedia/) : `/airmedia/*`
   - [ ] Get the AirMedia configuration

--- a/client/client.go
+++ b/client/client.go
@@ -76,6 +76,8 @@ type Client interface {
 	MoveFiles(ctx context.Context, sources []string, destination string, mode types.FileMoveMode) (result types.FileSystemTask, err error)
 	CopyFiles(ctx context.Context, sources []string, destination string, mode types.FileCopyMode) (result types.FileSystemTask, err error)
 	ExtractFile(ctx context.Context, payload types.ExtractFilePayload) (task types.FileSystemTask, err error)
+	// system
+	GetSystemInfo(ctx context.Context) (types.SystemConfig, error)
 	// downloads
 	ListDownloadTasks(ctx context.Context) ([]types.DownloadTask, error)
 	GetDownloadTask(ctx context.Context, identifier int64) (types.DownloadTask, error)

--- a/client/system.go
+++ b/client/system.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+func (c *client) GetSystemInfo(ctx context.Context) (result types.SystemConfig, err error) {
+	response, err := c.get(ctx, "system/", c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to GET system/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to get system info from generic response: %w", err)
+	}
+
+	return result, nil
+}

--- a/client/system_test.go
+++ b/client/system_test.go
@@ -1,0 +1,119 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/nikolalohinski/free-go/client"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("system", func() {
+	var (
+		freeboxClient client.Client
+
+		server   *ghttp.Server
+		endpoint = new(string)
+
+		sessionToken = new(string)
+
+		returnedErr = new(error)
+	)
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		DeferCleanup(server.Close)
+
+		*endpoint = server.Addr()
+
+		freeboxClient = Must(client.New(*endpoint, version)).
+			WithAppID(appID).
+			WithPrivateToken(privateToken)
+
+		*sessionToken = setupLoginFlow(server)
+	})
+
+	Context("getting the system info", func() {
+		returnedSystemInfo := new(types.SystemConfig)
+		JustBeforeEach(func() {
+			*returnedSystemInfo, *returnedErr = freeboxClient.GetSystemInfo(context.Background())
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/system/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"mac": "F4:CA:E5:5C:EA:14",
+								"box_flavor": "light",
+								"temp_cpub": 63,
+								"disk_status": "active",
+								"box_authenticated": true,
+								"board_name": "fbxgw1r",
+								"fan_rpm": 1832,
+								"temp_sw": 52,
+								"uptime": "6 jours 22 heures 9 minutes 46 secondes",
+								"uptime_val": 598186,
+								"user_main_storage": "Disque 1",
+								"temp_cpum": 62,
+								"serial": "805400T144100853",
+								"firmware_version": "6.6.6"
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the correct system info", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedSystemInfo).To(Equal(types.SystemConfig{
+					Mac:              "F4:CA:E5:5C:EA:14",
+					BoxFlavor:        types.BoxFlavorLight,
+					TempCPUB:         63,
+					DiskStatus:       types.DiskStatusActive,
+					BoxAuthenticated: true,
+					BoardName:        "fbxgw1r",
+					FanRPM:           1832,
+					TempSW:           52,
+					Uptime:           "6 jours 22 heures 9 minutes 46 secondes",
+					UptimeVal:        598186,
+					UserMainStorage:  "Disque 1",
+					TempCPUM:         62,
+					Serial:           "805400T144100853",
+					FirmwareVersion:  "6.6.6",
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/system/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": "not-an-object"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/types/system.go
+++ b/types/system.go
@@ -1,0 +1,35 @@
+package types
+
+type diskStatus string
+
+const (
+	DiskStatusNotDetected  diskStatus = "not_detected"
+	DiskStatusDisabled     diskStatus = "disabled"
+	DiskStatusInitializing diskStatus = "initializing"
+	DiskStatusError        diskStatus = "error"
+	DiskStatusActive       diskStatus = "active"
+)
+
+type boxFlavor string
+
+const (
+	BoxFlavorFull  boxFlavor = "full"
+	BoxFlavorLight boxFlavor = "light"
+)
+
+type SystemConfig struct {
+	FirmwareVersion  string     `json:"firmware_version"`  // freebox firmware version
+	Mac              string     `json:"mac"`               // freebox mac address
+	Serial           string     `json:"serial"`            // freebox serial number
+	Uptime           string     `json:"uptime"`            // readable freebox uptime
+	UptimeVal        int64      `json:"uptime_val"`        // freebox uptime (in seconds)
+	BoardName        string     `json:"board_name"`        // freebox hardware revision
+	TempCPUM         int        `json:"temp_cpum"`         // temp cpum (°C)
+	TempSW           int        `json:"temp_sw"`           // temp sw (°C)
+	TempCPUB         int        `json:"temp_cpub"`         // temp cpub (°C)
+	FanRPM           int        `json:"fan_rpm"`           // fan rpm
+	BoxAuthenticated bool       `json:"box_authenticated"` // is the box authenticated
+	DiskStatus       diskStatus `json:"disk_status"`       // internal disk status
+	BoxFlavor        boxFlavor  `json:"box_flavor"`        // box flavor
+	UserMainStorage  string     `json:"user_main_storage"` // label of the storage partition for user data
+}


### PR DESCRIPTION
## Summary

- Add `GetSystemInfo(ctx)` method to the client
- Add `types.SystemConfig` with all fields from the API spec, and `diskStatus` / `boxFlavor` enum types
- Add Ginkgo tests covering success, server error, and unexpected payload cases

## API

Implements the [System API](https://dev.freebox.fr/sdk/os/system/):
- `GET /system/` [UNSTABLE]