### PR TITLE
feat(vpn): add OpenVPN server config and user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,14 @@ At the time of this writing, generating credentials can only be done via the Fre
 - [ ] [Universal Plug and Play Audio Video](https://dev.freebox.fr/sdk/os/upnpav/) : `/upnpav/*`
   - [ ] Get the UPnP AV configuration
   - [ ] Update UPnP AV configuration
+- [x] [VPN](https://dev.freebox.fr/sdk/os/vpn/) : `/vpn/*`
+  - [x] Get the VPN configuration
+  - [x] Update the VPN configuration
+  - [x] Get the list of VPN clients
+  - [x] Get a specific VPN client
+  - [x] Update a VPN client
+  - [x] Delete a VPN client
+  - [x] Create a VPN client
 
 ## Development
 

--- a/client/client.go
+++ b/client/client.go
@@ -90,6 +90,15 @@ type Client interface {
 	CancelUploadTask(ctx context.Context, identifier int64) error
 	DeleteUploadTask(ctx context.Context, identifier int64) error
 	CleanUploadTasks(ctx context.Context) error
+	// vpn
+	GetOpenVPNServerConfig(ctx context.Context) (types.OpenVPNServerConfig, error)
+	UpdateOpenVPNServerConfig(ctx context.Context, payload types.OpenVPNServerConfig) (types.OpenVPNServerConfig, error)
+	ListVPNUsers(ctx context.Context) ([]types.VPNUser, error)
+	GetVPNUser(ctx context.Context, login string) (types.VPNUser, error)
+	CreateVPNUser(ctx context.Context, payload types.VPNUserPayload) (types.VPNUser, error)
+	UpdateVPNUser(ctx context.Context, login string, payload types.VPNUserPayload) (types.VPNUser, error)
+	DeleteVPNUser(ctx context.Context, login string) error
+	GetVPNUserClientConfig(ctx context.Context, login string) (string, error)
 }
 
 type HTTPClient interface {

--- a/client/constants.go
+++ b/client/constants.go
@@ -22,6 +22,7 @@ const (
 	ErrPathNotFound               = Error("path not found")
 	ErrTaskNotFound               = Error("task not found")
 	ErrDestinationConflict        = Error("file or folder already exists")
+	ErrVPNUserNotFound            = Error("vpn user not found")
 )
 
 var (

--- a/client/vpn.go
+++ b/client/vpn.go
@@ -1,0 +1,141 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+const (
+	codeVPNUserNotFound = "noent"
+)
+
+// GetOpenVPNServerConfig returns the current OpenVPN server configuration.
+func (c *client) GetOpenVPNServerConfig(ctx context.Context) (config types.OpenVPNServerConfig, err error) {
+	response, err := c.get(ctx, "vpn/openvpn/", c.withSession(ctx))
+	if err != nil {
+		return config, fmt.Errorf("failed to GET vpn/openvpn/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &config); err != nil {
+		return config, fmt.Errorf("failed to get OpenVPN server config from generic response: %w", err)
+	}
+
+	return config, nil
+}
+
+// UpdateOpenVPNServerConfig updates the OpenVPN server configuration.
+func (c *client) UpdateOpenVPNServerConfig(ctx context.Context, payload types.OpenVPNServerConfig) (config types.OpenVPNServerConfig, err error) {
+	response, err := c.put(ctx, "vpn/openvpn/", payload, c.withSession(ctx))
+	if err != nil {
+		return config, fmt.Errorf("failed to PUT vpn/openvpn/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &config); err != nil {
+		return config, fmt.Errorf("failed to get updated OpenVPN server config from generic response: %w", err)
+	}
+
+	return config, nil
+}
+
+// ListVPNUsers returns all configured VPN user accounts.
+func (c *client) ListVPNUsers(ctx context.Context) ([]types.VPNUser, error) {
+	response, err := c.get(ctx, "vpn/user/", c.withSession(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to GET vpn/user/ endpoint: %w", err)
+	}
+
+	result := make([]types.VPNUser, 0)
+	if response.Result != nil {
+		if err = c.fromGenericResponse(response, &result); err != nil {
+			return nil, fmt.Errorf("failed to get VPN users from generic response: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// GetVPNUser returns the VPN user account with the given login.
+func (c *client) GetVPNUser(ctx context.Context, login string) (user types.VPNUser, err error) {
+	response, err := c.get(ctx, fmt.Sprintf("vpn/user/%s", login), c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeVPNUserNotFound {
+			return user, ErrVPNUserNotFound
+		}
+
+		return user, fmt.Errorf("failed to GET vpn/user/%s endpoint: %w", login, err)
+	}
+
+	if err = c.fromGenericResponse(response, &user); err != nil {
+		return user, fmt.Errorf("failed to get VPN user from generic response: %w", err)
+	}
+
+	return user, nil
+}
+
+// CreateVPNUser creates a new VPN user account.
+func (c *client) CreateVPNUser(ctx context.Context, payload types.VPNUserPayload) (user types.VPNUser, err error) {
+	response, err := c.post(ctx, "vpn/user/", payload, c.withSession(ctx))
+	if err != nil {
+		return user, fmt.Errorf("failed to POST vpn/user/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &user); err != nil {
+		return user, fmt.Errorf("failed to get created VPN user from generic response: %w", err)
+	}
+
+	return user, nil
+}
+
+// UpdateVPNUser updates an existing VPN user account.
+func (c *client) UpdateVPNUser(ctx context.Context, login string, payload types.VPNUserPayload) (user types.VPNUser, err error) {
+	response, err := c.put(ctx, fmt.Sprintf("vpn/user/%s", login), payload, c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeVPNUserNotFound {
+			return user, ErrVPNUserNotFound
+		}
+
+		return user, fmt.Errorf("failed to PUT vpn/user/%s endpoint: %w", login, err)
+	}
+
+	if err = c.fromGenericResponse(response, &user); err != nil {
+		return user, fmt.Errorf("failed to get updated VPN user from generic response: %w", err)
+	}
+
+	return user, nil
+}
+
+// DeleteVPNUser deletes a VPN user account.
+func (c *client) DeleteVPNUser(ctx context.Context, login string) error {
+	response, err := c.delete(ctx, fmt.Sprintf("vpn/user/%s", login), c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeVPNUserNotFound {
+			return ErrVPNUserNotFound
+		}
+
+		return fmt.Errorf("failed to DELETE vpn/user/%s endpoint: %w", login, err)
+	}
+
+	return nil
+}
+
+// GetVPNUserClientConfig returns the OpenVPN client configuration (.ovpn content) for the given user.
+func (c *client) GetVPNUserClientConfig(ctx context.Context, login string) (string, error) {
+	response, err := c.get(ctx, fmt.Sprintf("vpn/user/%s/config/openvpn", login), c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == codeVPNUserNotFound {
+			return "", ErrVPNUserNotFound
+		}
+
+		return "", fmt.Errorf("failed to GET vpn/user/%s/config/openvpn endpoint: %w", login, err)
+	}
+
+	var config string
+	if err = json.Unmarshal(response.Result, &config); err != nil {
+		return "", fmt.Errorf("failed to decode VPN client config from response: %w", err)
+	}
+
+	return config, nil
+}

--- a/client/vpn_test.go
+++ b/client/vpn_test.go
@@ -1,0 +1,544 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/nikolalohinski/free-go/client"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("vpn", func() {
+	var (
+		freeboxClient client.Client
+
+		ctx context.Context
+
+		server   *ghttp.Server
+		endpoint = new(string)
+
+		sessionToken = new(string)
+
+		returnedErr = new(error)
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		server = ghttp.NewServer()
+		DeferCleanup(server.Close)
+
+		*endpoint = server.Addr()
+
+		freeboxClient = Must(client.New(*endpoint, version)).
+			WithAppID(appID).
+			WithPrivateToken(privateToken)
+
+		*sessionToken = setupLoginFlow(server)
+	})
+
+	// ── OpenVPN server config ───────────────────────────────────────────────────
+
+	Context("getting the OpenVPN server config", func() {
+		returnedConfig := new(types.OpenVPNServerConfig)
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.GetOpenVPNServerConfig(ctx)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/openvpn/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"enabled": true,
+								"server_port": 1194,
+								"server_ip": "10.8.0.0",
+								"server_mask": "255.255.255.0",
+								"push_default_gw": false,
+								"push_dhcp": true,
+								"ca": "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n"
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the correct config", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(MatchFields(IgnoreExtras, Fields{
+					"Enabled":    Equal(true),
+					"ServerPort": Equal(int64(1194)),
+					"ServerIP":   Equal("10.8.0.0"),
+					"ServerMask": Equal("255.255.255.0"),
+					"PushDHCP":   Equal(true),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the context is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("updating the OpenVPN server config", func() {
+		var (
+			returnedConfig = new(types.OpenVPNServerConfig)
+			payload        = new(types.OpenVPNServerConfig)
+		)
+		BeforeEach(func() {
+			*payload = types.OpenVPNServerConfig{
+				Enabled:    true,
+				ServerPort: 1194,
+				ServerIP:   "10.8.0.0",
+				ServerMask: "255.255.255.0",
+			}
+		})
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.UpdateOpenVPNServerConfig(ctx, *payload)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/vpn/openvpn/", version)),
+						ghttp.VerifyContentType("application/json"),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSON(`{
+							"enabled": true,
+							"server_port": 1194,
+							"server_ip": "10.8.0.0",
+							"server_mask": "255.255.255.0",
+							"push_default_gw": false,
+							"push_dhcp": false
+						}`),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"enabled": true,
+								"server_port": 1194,
+								"server_ip": "10.8.0.0",
+								"server_mask": "255.255.255.0",
+								"push_default_gw": false,
+								"push_dhcp": false
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the updated config", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(MatchFields(IgnoreExtras, Fields{
+					"Enabled":    Equal(true),
+					"ServerPort": Equal(int64(1194)),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/vpn/openvpn/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": []
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	// ── VPN users ───────────────────────────────────────────────────────────────
+
+	Context("listing VPN users", func() {
+		returnedUsers := new([]types.VPNUser)
+		JustBeforeEach(func() {
+			*returnedUsers, *returnedErr = freeboxClient.ListVPNUsers(ctx)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/user/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": [
+								{"login": "perreux", "password": "", "description": "Perreux NAS"}
+							]
+						}`),
+					),
+				)
+			})
+			It("should return the correct users", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedUsers).To(HaveLen(1))
+				Expect((*returnedUsers)[0]).To(MatchFields(IgnoreExtras, Fields{
+					"VPNUserPayload": MatchFields(IgnoreExtras, Fields{
+						"Login":       Equal("perreux"),
+						"Description": Equal("Perreux NAS"),
+					}),
+				}))
+			})
+		})
+		Context("when there are no VPN users", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/user/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{"success": true}`),
+					),
+				)
+			})
+			It("should return an empty list", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedUsers).To(BeEmpty())
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("getting a VPN user", func() {
+		const login = "perreux"
+		returnedUser := new(types.VPNUser)
+		JustBeforeEach(func() {
+			*returnedUser, *returnedErr = freeboxClient.GetVPNUser(ctx, login)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/user/%s", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {"login": "perreux", "password": "", "description": "Perreux NAS"}
+						}`),
+					),
+				)
+			})
+			It("should return the correct user", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedUser).To(MatchFields(IgnoreExtras, Fields{
+					"VPNUserPayload": MatchFields(IgnoreExtras, Fields{
+						"Login": Equal("perreux"),
+					}),
+				}))
+			})
+		})
+		Context("when the VPN user is not found", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/user/%s", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "noent",
+							"msg": "User not found"
+						}`),
+					),
+				)
+			})
+			It("should return ErrVPNUserNotFound", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrVPNUserNotFound))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("creating a VPN user", func() {
+		var (
+			returnedUser = new(types.VPNUser)
+			payload      = new(types.VPNUserPayload)
+		)
+		BeforeEach(func() {
+			*payload = types.VPNUserPayload{
+				Login:       "perreux",
+				Password:    "secret",
+				Description: "Perreux NAS",
+			}
+		})
+		JustBeforeEach(func() {
+			*returnedUser, *returnedErr = freeboxClient.CreateVPNUser(ctx, *payload)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, fmt.Sprintf("/api/%s/vpn/user/", version)),
+						ghttp.VerifyContentType("application/json"),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSON(`{
+							"login": "perreux",
+							"password": "secret",
+							"description": "Perreux NAS"
+						}`),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {"login": "perreux", "password": "", "description": "Perreux NAS"}
+						}`),
+					),
+				)
+			})
+			It("should return the created user", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedUser).To(MatchFields(IgnoreExtras, Fields{
+					"VPNUserPayload": MatchFields(IgnoreExtras, Fields{
+						"Login": Equal("perreux"),
+					}),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, fmt.Sprintf("/api/%s/vpn/user/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{"success": true, "result": []}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("updating a VPN user", func() {
+		const login = "perreux"
+		var (
+			returnedUser = new(types.VPNUser)
+			payload      = new(types.VPNUserPayload)
+		)
+		BeforeEach(func() {
+			*payload = types.VPNUserPayload{
+				Login:    "perreux",
+				Password: "new-secret",
+			}
+		})
+		JustBeforeEach(func() {
+			*returnedUser, *returnedErr = freeboxClient.UpdateVPNUser(ctx, login, *payload)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/vpn/user/%s", version, login)),
+						ghttp.VerifyContentType("application/json"),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSON(`{"login": "perreux", "password": "new-secret"}`),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {"login": "perreux", "password": ""}
+						}`),
+					),
+				)
+			})
+			It("should return the updated user", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedUser).To(MatchFields(IgnoreExtras, Fields{
+					"VPNUserPayload": MatchFields(IgnoreExtras, Fields{
+						"Login": Equal("perreux"),
+					}),
+				}))
+			})
+		})
+		Context("when the VPN user is not found", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/vpn/user/%s", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "noent",
+							"msg": "User not found"
+						}`),
+					),
+				)
+			})
+			It("should return ErrVPNUserNotFound", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrVPNUserNotFound))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("deleting a VPN user", func() {
+		const login = "perreux"
+		JustBeforeEach(func() {
+			*returnedErr = freeboxClient.DeleteVPNUser(ctx, login)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodDelete, fmt.Sprintf("/api/%s/vpn/user/%s", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{"success": true}`),
+					),
+				)
+			})
+			It("should not return an error", func() {
+				Expect(*returnedErr).To(BeNil())
+			})
+		})
+		Context("when the VPN user is not found", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodDelete, fmt.Sprintf("/api/%s/vpn/user/%s", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "noent",
+							"msg": "User not found"
+						}`),
+					),
+				)
+			})
+			It("should return ErrVPNUserNotFound", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrVPNUserNotFound))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the context is nil", func() {
+			BeforeEach(func() {
+				ctx = nil
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	// ── VPN client config ───────────────────────────────────────────────────────
+
+	Context("getting the VPN client config", func() {
+		const login = "perreux"
+		returnedConfig := new(string)
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.GetVPNUserClientConfig(ctx, login)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/user/%s/config/openvpn", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": "client\nproto udp\nremote freebox.example.com 1194\n"
+						}`),
+					),
+				)
+			})
+			It("should return the .ovpn content", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(ContainSubstring("client"))
+				Expect(*returnedConfig).To(ContainSubstring("proto udp"))
+			})
+		})
+		Context("when the VPN user is not found", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/vpn/user/%s/config/openvpn", version, login)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "noent",
+							"msg": "User not found"
+						}`),
+					),
+				)
+			})
+			It("should return ErrVPNUserNotFound", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrVPNUserNotFound))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/types/vpn.go
+++ b/types/vpn.go
@@ -1,0 +1,29 @@
+package types
+
+// OpenVPNServerConfig is the OpenVPN server configuration.
+// Endpoint: GET/PUT /vpn/openvpn/
+// Note: field names are from the Freebox OS API — verify against a live Freebox with
+// DevTools if any mismatch is observed.
+type OpenVPNServerConfig struct {
+	Enabled       bool   `json:"enabled"`                  // Whether the OpenVPN server is enabled
+	ServerPort    int64  `json:"server_port"`              // UDP port the server listens on (default 1194)
+	ServerIP      string `json:"server_ip"`                // VPN subnet IP address (e.g. "10.8.0.0")
+	ServerMask    string `json:"server_mask"`              // VPN subnet mask (e.g. "255.255.255.0")
+	PushDefaultGW bool   `json:"push_default_gw"`          // Whether to push the default gateway to clients
+	PushDHCP      bool   `json:"push_dhcp"`                // Whether to push DHCP settings to clients
+	CA            string `json:"ca,omitempty"`             // CA certificate in PEM format (read-only, set by Freebox)
+	Cert          string `json:"cert,omitempty"`           // Server certificate in PEM format (read-only, set by Freebox)
+}
+
+// VPNUserPayload is the create/update payload for a VPN user.
+// Endpoint: POST /vpn/user/, PUT /vpn/user/{login}
+type VPNUserPayload struct {
+	Login       string `json:"login"`                    // Username (immutable after creation)
+	Password    string `json:"password"`                 // Password
+	Description string `json:"description,omitempty"`   // Optional description
+}
+
+// VPNUser is a VPN user account as returned by the API.
+type VPNUser struct {
+	VPNUserPayload
+}


### PR DESCRIPTION
## Summary

- Add `OpenVPNServerConfig` and `VPNUser`/`VPNUserPayload` types in `types/vpn.go`
- Add VPN client methods in `client/vpn.go`:
  - `GetOpenVPNServerConfig` / `UpdateOpenVPNServerConfig` — manage the Freebox built-in OpenVPN server (`GET/PUT /vpn/openvpn/`)
  - `ListVPNUsers`, `GetVPNUser`, `CreateVPNUser`, `UpdateVPNUser`, `DeleteVPNUser` — manage VPN user accounts (`/vpn/user/`)
  - `GetVPNUserClientConfig` — download the `.ovpn` config file for a user (`/vpn/user/{login}/config/openvpn`)
- Add `ErrVPNUserNotFound` error constant
- Register all new methods in the `Client` interface
- Unit tests in `client/vpn_test.go` covering all methods (happy path + not-found + server-down cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)