### PR TITLE
fix(fs): fix wrong endpoint name in MoveFiles error message

### DIFF
--- a/client/filesystem.go
+++ b/client/filesystem.go
@@ -139,7 +139,7 @@ func (c *client) MoveFiles(ctx context.Context, source []string, destination str
 			return result, ErrDestinationConflict
 		}
 
-		return result, fmt.Errorf("failed to POST to fs/mkdir/ endpoint: %w", err)
+		return result, fmt.Errorf("failed to POST to fs/mv/ endpoint: %w", err)
 	}
 
 	if err = c.fromGenericResponse(response, &result); err != nil {


### PR DESCRIPTION
## Summary
- Error message in `MoveFiles` incorrectly reported `"fs/mkdir/"` instead of `"fs/mv/"`, making failures harder to diagnose

## Test plan
- [x] Existing MoveFiles tests pass (string-only fix, no new test needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)