### PR TITLE
feat(fs): add ListFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ At the time of this writing, generating credentials can only be done via the Fre
   - [x] Get file information
   - [x] Download a file
   - [x] Remove files
-  - [ ] List files
+  - [x] List files
   - [x] Move files
   - [x] Copy files
   - [ ] Concatenate files

--- a/client/client.go
+++ b/client/client.go
@@ -73,6 +73,7 @@ type Client interface {
 	AddHashFileTask(ctx context.Context, payload types.HashPayload) (task types.FileSystemTask, err error)
 	GetHashResult(ctx context.Context, identifier int64) (result string, err error)
 	GetFile(ctx context.Context, path string) (result types.File, err error)
+	ListFiles(ctx context.Context, path string) (files []types.FileInfo, err error)
 	MoveFiles(ctx context.Context, sources []string, destination string, mode types.FileMoveMode) (result types.FileSystemTask, err error)
 	CopyFiles(ctx context.Context, sources []string, destination string, mode types.FileCopyMode) (result types.FileSystemTask, err error)
 	ExtractFile(ctx context.Context, payload types.ExtractFilePayload) (task types.FileSystemTask, err error)

--- a/client/filesystem.go
+++ b/client/filesystem.go
@@ -59,6 +59,19 @@ func (c *client) RemoveFiles(ctx context.Context, paths []string) (task types.Fi
 	return task, nil
 }
 
+func (c *client) ListFiles(ctx context.Context, path string) (files []types.FileInfo, err error) {
+	response, err := c.get(ctx, "fs/ls/"+base64.StdEncoding.EncodeToString([]byte(path)), c.withSession(ctx))
+	if err != nil {
+		return files, fmt.Errorf("failed to GET fs/ls/%s endpoint: %w", path, err)
+	}
+
+	if err = c.fromGenericResponse(response, &files); err != nil {
+		return files, fmt.Errorf("failed to get a list of files from a generic response: %w", err)
+	}
+
+	return files, nil
+}
+
 func (c *client) UpdateFileSystemTask(ctx context.Context, identifier int64, payload types.FileSytemTaskUpdate) (task types.FileSystemTask, err error) {
 	response, err := c.put(ctx, fmt.Sprintf("fs/tasks/%d", identifier), payload, c.withSession(ctx))
 	if err != nil {

--- a/client/filesystem.go
+++ b/client/filesystem.go
@@ -60,9 +60,15 @@ func (c *client) RemoveFiles(ctx context.Context, paths []string) (task types.Fi
 }
 
 func (c *client) ListFiles(ctx context.Context, path string) (files []types.FileInfo, err error) {
-	response, err := c.get(ctx, "fs/ls/"+base64.StdEncoding.EncodeToString([]byte(path)), c.withSession(ctx))
+	base64Path := base64.StdEncoding.EncodeToString([]byte(path))
+
+	response, err := c.get(ctx, "fs/ls/"+base64Path, c.withSession(ctx))
 	if err != nil {
-		return files, fmt.Errorf("failed to GET fs/ls/%s endpoint: %w", path, err)
+		if response != nil && response.ErrorCode == pathNotFoundCode {
+			return files, ErrPathNotFound
+		}
+
+		return files, fmt.Errorf("failed to GET fs/ls/%s endpoint: %w", base64Path, err)
 	}
 
 	if err = c.fromGenericResponse(response, &files); err != nil {

--- a/client/filesystem_test.go
+++ b/client/filesystem_test.go
@@ -295,15 +295,12 @@ var _ = Describe("filesystem", func() {
 				server.AppendHandlers(ghttp.CombineHandlers(
 					ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/fs/ls/%s", version, dirPathBase64)),
 					verifyAuth(*sessionToken),
-					ghttp.RespondWith(http.StatusOK, `{
-						"msg": "Erreur lors de la récupération de la liste des fichiers : Le fichier n'existe pas",
-						"success": false,
-						"error_code": "path_not_found"
-					}`),
+					ghttp.RespondWith(http.StatusOK, `{"success":false,"error_code":"path_not_found","msg":"not found"}`),
 				))
 			})
 			It("should return an error", func() {
 				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrPathNotFound))
 			})
 		})
 		Context("when the server fails to respond", func() {

--- a/client/filesystem_test.go
+++ b/client/filesystem_test.go
@@ -238,6 +238,83 @@ var _ = Describe("filesystem", func() {
 			})
 		})
 	})
+	Context("listing files", func() {
+		const (
+			dirPath       = "path/to/dir"
+			dirPathBase64 = "cGF0aC90by9kaXI="
+		)
+		returnedFiles := new([]types.FileInfo)
+		JustBeforeEach(func(ctx SpecContext) {
+			*returnedFiles, *returnedErr = freeboxClient.ListFiles(ctx, dirPath)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/fs/ls/%s", version, dirPathBase64)),
+					verifyAuth(*sessionToken),
+					ghttp.RespondWith(http.StatusOK, `{
+						"success": true,
+						"result": [
+							{"type": "file", "name": "foo.txt", "path": "cGF0aC90by9kaXIvZm9vLnR4dA==", "size": 1024, "index": 0, "link": false, "hidden": false, "modification": 1711657506, "mimetype": "text/plain", "parent": "cGF0aC90by9kaXI="},
+							{"type": "dir",  "name": "subdir",  "path": "cGF0aC90by9kaXIvc3ViZGly",     "size": 0,    "index": 1, "link": false, "hidden": false, "modification": 1711657506, "mimetype": "",          "parent": "cGF0aC90by9kaXI="}
+						]
+					}`),
+				))
+			})
+			It("should return the list of files", func() {
+				Expect(*returnedErr).ToNot(HaveOccurred())
+				Expect(*returnedFiles).To(HaveLen(2))
+				Expect((*returnedFiles)[0]).To(Equal(types.FileInfo{
+					Type:         "file",
+					Name:         "foo.txt",
+					Path:         "path/to/dir/foo.txt",
+					SizeBytes:    1024,
+					Index:        0,
+					Link:         false,
+					Hidden:       false,
+					Modification: 1711657506,
+					MimeType:     "text/plain",
+					Parent:       "path/to/dir",
+				}))
+				Expect((*returnedFiles)[1]).To(Equal(types.FileInfo{
+					Type:         "dir",
+					Name:         "subdir",
+					Path:         "path/to/dir/subdir",
+					SizeBytes:    0,
+					Index:        1,
+					Link:         false,
+					Hidden:       false,
+					Modification: 1711657506,
+					MimeType:     "",
+					Parent:       "path/to/dir",
+				}))
+			})
+		})
+		Context("when the server returns an error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/fs/ls/%s", version, dirPathBase64)),
+					verifyAuth(*sessionToken),
+					ghttp.RespondWith(http.StatusOK, `{
+						"msg": "Erreur lors de la récupération de la liste des fichiers : Le fichier n'existe pas",
+						"success": false,
+						"error_code": "path_not_found"
+					}`),
+				))
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
 	Context("updating filesystem task", func() {
 		const identifier int64 = 42
 		returnedTask := new(types.FileSystemTask)


### PR DESCRIPTION
## Summary
- Implements `ListFiles(ctx, path)` via `GET fs/ls/<base64path>`
- Adds the method to the `Client` interface
- Updates README to mark "List files" as implemented

## Test plan
- [x] Default success: verifies URL contains correct base64 path, returns correct `[]FileInfo`
- [x] Server error case
- [x] Server-closed case

🤖 Generated with [Claude Code](https://claude.com/claude-code)