### PR TITLE
feat(lan): add DeleteLanInterfaceHost

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	ListLanInterfaceInfo(context.Context) ([]types.LanInfo, error)
 	GetLanInterface(ctx context.Context, name string) (result []types.LanInterfaceHost, err error)
 	GetLanInterfaceHost(ctx context.Context, interfaceName, identifier string) (result types.LanInterfaceHost, err error)
+	DeleteLanInterfaceHost(ctx context.Context, interfaceName, identifier string) error
 	// virtual machines
 	GetVirtualMachineInfo(context.Context) (result types.VirtualMachinesInfo, err error)
 	GetVirtualMachineDistributions(context.Context) (result []types.VirtualMachineDistribution, err error)

--- a/client/lan_browser.go
+++ b/client/lan_browser.go
@@ -42,6 +42,23 @@ func (c *client) GetLanInterface(ctx context.Context, name string) (result []typ
 	return result, nil
 }
 
+func (c *client) DeleteLanInterfaceHost(ctx context.Context, interfaceName, identifier string) error {
+	response, err := c.delete(ctx, fmt.Sprintf("lan/browser/%s/%s", interfaceName, identifier), c.withSession(ctx))
+	if err != nil {
+		if response != nil && response.ErrorCode == interfaceNotFoundCode {
+			return ErrInterfaceNotFound
+		}
+
+		if response != nil && response.ErrorCode == interfaceHostNotFoundCode {
+			return ErrInterfaceHostNotFound
+		}
+
+		return fmt.Errorf("failed to DELETE lan/browser/%s/%s endpoint: %w", interfaceName, identifier, err)
+	}
+
+	return nil
+}
+
 func (c *client) GetLanInterfaceHost(ctx context.Context, interfaceName, identifier string) (result types.LanInterfaceHost, err error) {
 	response, err := c.get(ctx, fmt.Sprintf("lan/browser/%s/%s", interfaceName, identifier), c.withSession(ctx))
 	if err != nil {

--- a/client/lan_browser_test.go
+++ b/client/lan_browser_test.go
@@ -481,4 +481,75 @@ var _ = Describe("lan browser", func() {
 			})
 		})
 	})
+	Context("deleting a lan interface host", func() {
+		const (
+			interfaceName  = "pub"
+			hostIdentifier = "ether-7e:ec:37:cd:5b:6a"
+		)
+		JustBeforeEach(func() {
+			*returnedErr = freeboxClient.DeleteLanInterfaceHost(context.Background(), interfaceName, hostIdentifier)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodDelete, fmt.Sprintf("/api/%s/lan/browser/%s/%s", version, interfaceName, hostIdentifier)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{"success":true}`),
+					),
+				)
+			})
+			It("should return no error", func() {
+				Expect(*returnedErr).ToNot(HaveOccurred())
+			})
+		})
+		Context("when the interface does not exist", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodDelete, fmt.Sprintf("/api/%s/lan/browser/%s/%s", version, interfaceName, hostIdentifier)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "nodev",
+							"msg": "Interface invalide"
+						}`),
+					),
+				)
+			})
+			It("should return the correct error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrInterfaceNotFound))
+				Expect((*returnedErr).Error()).To(Equal("interface not found"))
+			})
+		})
+		Context("when the host does not exist", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodDelete, fmt.Sprintf("/api/%s/lan/browser/%s/%s", version, interfaceName, hostIdentifier)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "nohost",
+							"msg": "Pas d'hôte avec cet identifiant"
+						}`),
+					),
+				)
+			})
+			It("should return the correct error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+				Expect(*returnedErr).To(Equal(client.ErrInterfaceHostNotFound))
+				Expect((*returnedErr).Error()).To(Equal("interface host not found"))
+			})
+		})
+		Context("when server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- Adds `DeleteLanInterfaceHost(ctx, interfaceName, identifier)` via `DELETE lan/browser/<iface>/<id>`
- Returns `ErrInterfaceNotFound` on `nodev` and `ErrInterfaceHostNotFound` on `nohost`
- Adds the method to the `Client` interface

## Test plan
- [x] Default success
- [x] Interface not found → `ErrInterfaceNotFound`
- [x] Host not found → `ErrInterfaceHostNotFound`
- [x] Server-closed case

🤖 Generated with [Claude Code](https://claude.com/claude-code)