### PR TITLE
fix(lan): handle primary_name_manual serialized as empty string

### DIFF
--- a/client/lan_browser_test.go
+++ b/client/lan_browser_test.go
@@ -284,6 +284,59 @@ var _ = Describe("lan browser", func() {
 				Expect(client.ErrInterfaceNotFound.Error()).To(Equal("interface not found"))
 			})
 		})
+		Context("when primary_name_manual is an empty string", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/lan/browser/%s", version, interfaceName)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": [{
+								"l2ident": {
+									"id": "7E:EC:37:CD:5B:6A",
+									"type": "mac_address"
+								},
+								"active": false,
+								"persistent": false,
+								"names": [
+									{
+										"name": "test",
+										"source": "dhcp"
+									}
+								],
+								"vendor_name": "",
+								"host_type": "workstation",
+								"interface": "pub",
+								"id": "ether-7e:ec:37:cd:5b:6a",
+								"last_time_reachable": 1682579132,
+								"primary_name_manual": "",
+								"l3connectivities": [
+									{
+										"addr": "192.168.1.254",
+										"active": false,
+										"reachable": false,
+										"last_activity": 1682579111,
+										"af": "ipv4",
+										"last_time_reachable": 1682579111
+									}
+								],
+								"default_name": "testing",
+								"first_activity": 1682578724,
+								"reachable": false,
+								"last_activity": 1682579132,
+								"primary_name": "testing"
+							}]
+						}`),
+					),
+				)
+			})
+			It("should return no error and primary_name_manual should be false", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedLanInterfaceHosts).To(HaveLen(1))
+				Expect((*returnedLanInterfaceHosts)[0].PrimaryNameManual).To(BeFalse())
+			})
+		})
 		Context("when server fails to respond", func() {
 			BeforeEach(func() {
 				server.Close()
@@ -413,6 +466,58 @@ var _ = Describe("lan browser", func() {
 					},
 				},
 				))
+			})
+		})
+		Context("when primary_name_manual is an empty string", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/lan/browser/%s/%s", version, interfaceName, hostIdentifier)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"l2ident": {
+									"id": "7E:EC:37:CD:5B:6A",
+									"type": "mac_address"
+								},
+								"active": false,
+								"persistent": false,
+								"names": [
+									{
+										"name": "test",
+										"source": "dhcp"
+									}
+								],
+								"vendor_name": "",
+								"host_type": "workstation",
+								"interface": "pub",
+								"id": "ether-7e:ec:37:cd:5b:6a",
+								"last_time_reachable": 1682579132,
+								"primary_name_manual": "",
+								"l3connectivities": [
+									{
+										"addr": "192.168.1.254",
+										"active": false,
+										"reachable": false,
+										"last_activity": 1682579111,
+										"af": "ipv4",
+										"last_time_reachable": 1682579111
+									}
+								],
+								"default_name": "testing",
+								"first_activity": 1682578724,
+								"reachable": false,
+								"last_activity": 1682579132,
+								"primary_name": "testing"
+							}
+						}`),
+					),
+				)
+			})
+			It("should return no error and primary_name_manual should be false", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(returnedLanInterfaceHost.PrimaryNameManual).To(BeFalse())
 			})
 		})
 		Context("when the interface does not exist", func() {

--- a/types/lan_browser.go
+++ b/types/lan_browser.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type LanInfo struct {
 	Name      string `json:"name"`
 	HostCount int    `json:"host_count"`
@@ -68,6 +73,48 @@ type LanInterfaceHost struct {
 	DefaultName string              `json:"default_name"`
 	Interface   string              `json:"interface"`
 	Model       string              `json:"model"`
+}
+
+// UnmarshalJSON handles primary_name_manual being a bool or an empty string from the API.
+func (o *LanInterfaceHost) UnmarshalJSON(data []byte) error {
+	type Alias LanInterfaceHost
+
+	aux := &struct {
+		PrimaryNameManual json.RawMessage `json:"primary_name_manual"`
+		*Alias
+	}{
+		Alias: (*Alias)(o),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal LanInterfaceHost: %w", err)
+	}
+
+	if len(aux.PrimaryNameManual) == 0 {
+		o.PrimaryNameManual = false
+
+		return nil
+	}
+
+	var boolValue bool
+	if err := json.Unmarshal(aux.PrimaryNameManual, &boolValue); err == nil {
+		o.PrimaryNameManual = boolValue
+
+		return nil
+	}
+
+	var stringValue string
+	if err := json.Unmarshal(aux.PrimaryNameManual, &stringValue); err == nil {
+		if stringValue == "" {
+			o.PrimaryNameManual = false
+
+			return nil
+		}
+
+		return fmt.Errorf("received unexpected non-empty string for primary_name_manual: '%s'", stringValue)
+	}
+
+	return fmt.Errorf("failed to parse primary_name_manual field: '%s'", string(aux.PrimaryNameManual))
 }
 
 type LanHostAccessPoint struct {

--- a/types/lan_browser_test.go
+++ b/types/lan_browser_test.go
@@ -1,0 +1,67 @@
+package types_test
+
+import (
+	"encoding/json"
+
+	"github.com/nikolalohinski/free-go/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LanInterfaceHost", func() {
+	returnedErr := new(error)
+
+	Context("json unmarshal of primary_name_manual", func() {
+		var (
+			payload []byte
+			host    *types.LanInterfaceHost
+		)
+
+		BeforeEach(func() {
+			host = new(types.LanInterfaceHost)
+		})
+
+		JustBeforeEach(func() {
+			*returnedErr = json.Unmarshal(payload, host)
+		})
+
+		Context("when primary_name_manual is false (bool)", func() {
+			BeforeEach(func() {
+				payload = []byte(`{"primary_name_manual": false}`)
+			})
+			It("should set PrimaryNameManual to false with no error", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(host.PrimaryNameManual).To(BeFalse())
+			})
+		})
+
+		Context("when primary_name_manual is true (bool)", func() {
+			BeforeEach(func() {
+				payload = []byte(`{"primary_name_manual": true}`)
+			})
+			It("should set PrimaryNameManual to true with no error", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(host.PrimaryNameManual).To(BeTrue())
+			})
+		})
+
+		Context("when primary_name_manual is an empty string", func() {
+			BeforeEach(func() {
+				payload = []byte(`{"primary_name_manual": ""}`)
+			})
+			It("should set PrimaryNameManual to false with no error", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(host.PrimaryNameManual).To(BeFalse())
+			})
+		})
+
+		Context("when primary_name_manual is a non-empty string", func() {
+			BeforeEach(func() {
+				payload = []byte(`{"primary_name_manual": "unexpected"}`)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- The Freebox API occasionally returns `primary_name_manual` as `""` instead of `false`, causing `json.Unmarshal` to fail on `LanInterfaceHost`
- Custom `UnmarshalJSON` normalises both representations to `bool`, treating any empty string as `false` and returning an error for non-empty strings

## Test plan
- [x] Integration test: `""` response → `PrimaryNameManual == false`, no error
- [x] Unit tests in `types/lan_browser_test.go`: `false` (bool), `true` (bool), `""` (→ `false`), non-empty string (→ error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)