### PR TITLE
feat(netshare): add Samba and AFP configuration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ At the time of this writing, generating credentials can only be done via the Fre
 - [ ] [Universal Plug and Play Audio Video](https://dev.freebox.fr/sdk/os/upnpav/) : `/upnpav/*`
   - [ ] Get the UPnP AV configuration
   - [ ] Update UPnP AV configuration
+- [x] [Network Share](https://dev.freebox.fr/sdk/os/network_share/) : `/netshare/*`
+  - [x] Get the Samba configuration
+  - [x] Update the Samba configuration
+  - [x] Get the AFP configuration
+  - [x] Update the AFP configuration
 - [x] [VPN](https://dev.freebox.fr/sdk/os/vpn/) : `/vpn/*`
   - [x] Get the VPN configuration
   - [x] Update the VPN configuration

--- a/client/client.go
+++ b/client/client.go
@@ -103,6 +103,11 @@ type Client interface {
 	UpdateVPNUser(ctx context.Context, login string, payload types.VPNUserPayload) (types.VPNUser, error)
 	DeleteVPNUser(ctx context.Context, login string) error
 	GetVPNUserClientConfig(ctx context.Context, login string) (string, error)
+	// netshare
+	GetSambaConfiguration(ctx context.Context) (types.SambaConfiguration, error)
+	UpdateSambaConfiguration(ctx context.Context, payload types.SambaConfigurationPayload) (types.SambaConfiguration, error)
+	GetAFPConfiguration(ctx context.Context) (types.AFPConfiguration, error)
+	UpdateAFPConfiguration(ctx context.Context, payload types.AFPConfigurationPayload) (types.AFPConfiguration, error)
 }
 
 type HTTPClient interface {

--- a/client/netshare.go
+++ b/client/netshare.go
@@ -41,8 +41,10 @@ func (c *client) GetAFPConfiguration(ctx context.Context) (result types.AFPConfi
 		return result, fmt.Errorf("failed to GET netshare/afp/ endpoint: %w", err)
 	}
 
-	if err = c.fromGenericResponse(response, &result); err != nil {
-		return result, fmt.Errorf("failed to get AFP configuration from generic response: %w", err)
+	if response.Result != nil {
+		if err = c.fromGenericResponse(response, &result); err != nil {
+			return types.AFPConfiguration{}, fmt.Errorf("failed to get AFP configuration from generic response: %w", err)
+		}
 	}
 
 	return result, nil

--- a/client/netshare.go
+++ b/client/netshare.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nikolalohinski/free-go/types"
+)
+
+func (c *client) GetSambaConfiguration(ctx context.Context) (result types.SambaConfiguration, err error) {
+	response, err := c.get(ctx, "netshare/samba/", c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to GET netshare/samba/ endpoint: %w", err)
+	}
+
+	if response.Result != nil {
+		if err = c.fromGenericResponse(response, &result); err != nil {
+			return types.SambaConfiguration{}, fmt.Errorf("failed to get Samba configuration from generic response: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+func (c *client) UpdateSambaConfiguration(ctx context.Context, payload types.SambaConfigurationPayload) (result types.SambaConfiguration, err error) {
+	response, err := c.put(ctx, "netshare/samba/", payload, c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to PUT netshare/samba/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to update Samba configuration from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) GetAFPConfiguration(ctx context.Context) (result types.AFPConfiguration, err error) {
+	response, err := c.get(ctx, "netshare/afp/", c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to GET netshare/afp/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to get AFP configuration from generic response: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *client) UpdateAFPConfiguration(ctx context.Context, payload types.AFPConfigurationPayload) (result types.AFPConfiguration, err error) {
+	response, err := c.put(ctx, "netshare/afp/", payload, c.withSession(ctx))
+	if err != nil {
+		return result, fmt.Errorf("failed to PUT netshare/afp/ endpoint: %w", err)
+	}
+
+	if err = c.fromGenericResponse(response, &result); err != nil {
+		return result, fmt.Errorf("failed to update AFP configuration from generic response: %w", err)
+	}
+
+	return result, nil
+}

--- a/client/netshare_test.go
+++ b/client/netshare_test.go
@@ -1,0 +1,379 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/nikolalohinski/free-go/client"
+	"github.com/nikolalohinski/free-go/types"
+)
+
+var _ = Describe("netshare", func() {
+	var (
+		freeboxClient client.Client
+
+		ctx context.Context
+
+		server   *ghttp.Server
+		endpoint = new(string)
+
+		sessionToken = new(string)
+
+		returnedErr = new(error)
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		server = ghttp.NewServer()
+		DeferCleanup(server.Close)
+
+		*endpoint = server.Addr()
+
+		freeboxClient = Must(client.New(*endpoint, version)).
+			WithAppID(appID).
+			WithPrivateToken(privateToken)
+
+		*sessionToken = setupLoginFlow(server)
+	})
+
+	// ── Samba ────────────────────────────────────────────────────────────────────
+
+	Context("getting the Samba configuration", func() {
+		returnedConfig := new(types.SambaConfiguration)
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.GetSambaConfiguration(ctx)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/netshare/samba/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"file_share_enabled": true,
+								"print_share_enabled": false,
+								"logon_enabled": true,
+								"logon_user": "freebox",
+								"workgroup": "WORKGROUP",
+								"smbv2_enabled": true
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the correct Samba configuration", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(MatchFields(IgnoreExtras, Fields{
+					"FileShareEnabled":  BeTrue(),
+					"PrintShareEnabled": BeFalse(),
+					"LogonEnabled":      BeTrue(),
+					"LogonUser":         Equal("freebox"),
+					"Workgroup":         Equal("WORKGROUP"),
+					"V2Enabled":         BeTrue(),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/netshare/samba/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": "not-an-object"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("updating the Samba configuration", func() {
+		var (
+			returnedConfig = new(types.SambaConfiguration)
+			payload        = new(types.SambaConfigurationPayload)
+		)
+		BeforeEach(func() {
+			*payload = types.SambaConfigurationPayload{
+				SambaConfiguration: types.SambaConfiguration{
+					FileShareEnabled: true,
+					Workgroup:        "MYGROUP",
+					LogonEnabled:     true,
+					LogonUser:        "freebox",
+					V2Enabled:        true,
+				},
+				LoginPassword: "s3cr3t",
+			}
+		})
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.UpdateSambaConfiguration(ctx, *payload)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/netshare/samba/", version)),
+						ghttp.VerifyContentType("application/json"),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSON(`{
+							"file_share_enabled": true,
+							"print_share_enabled": false,
+							"logon_enabled": true,
+							"logon_user": "freebox",
+							"workgroup": "MYGROUP",
+							"smbv2_enabled": true,
+							"login_password": "s3cr3t"
+						}`),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"file_share_enabled": true,
+								"print_share_enabled": false,
+								"logon_enabled": true,
+								"logon_user": "freebox",
+								"workgroup": "MYGROUP",
+								"smbv2_enabled": true
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the updated Samba configuration", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(MatchFields(IgnoreExtras, Fields{
+					"FileShareEnabled": BeTrue(),
+					"Workgroup":        Equal("MYGROUP"),
+					"LogonEnabled":     BeTrue(),
+					"LogonUser":        Equal("freebox"),
+					"V2Enabled":        BeTrue(),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an api error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/netshare/samba/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "invalid_workgroup_name",
+							"msg": "Invalid workgroup name"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/netshare/samba/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": []
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	// ── AFP ──────────────────────────────────────────────────────────────────────
+
+	Context("getting the AFP configuration", func() {
+		returnedConfig := new(types.AFPConfiguration)
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.GetAFPConfiguration(ctx)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/netshare/afp/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"enabled": true,
+								"guest_allow": "none",
+								"server_type": "macpro",
+								"login_name": "afpuser"
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the correct AFP configuration", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(MatchFields(IgnoreExtras, Fields{
+					"Enabled":    BeTrue(),
+					"GuestAllow": Equal("none"),
+					"ServerType": Equal(types.NetshareAFPServerTypeMacPro),
+					"LoginName":  Equal("afpuser"),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, fmt.Sprintf("/api/%s/netshare/afp/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": "not-an-object"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("updating the AFP configuration", func() {
+		var (
+			returnedConfig = new(types.AFPConfiguration)
+			payload        = new(types.AFPConfigurationPayload)
+		)
+		BeforeEach(func() {
+			*payload = types.AFPConfigurationPayload{
+				AFPConfiguration: types.AFPConfiguration{
+					Enabled:    true,
+					GuestAllow: "none",
+					ServerType: types.NetshareAFPServerTypeMacBook,
+					LoginName:  "afpuser",
+				},
+				LoginPassword: "afppass",
+			}
+		})
+		JustBeforeEach(func() {
+			*returnedConfig, *returnedErr = freeboxClient.UpdateAFPConfiguration(ctx, *payload)
+		})
+		Context("default", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/netshare/afp/", version)),
+						ghttp.VerifyContentType("application/json"),
+						verifyAuth(*sessionToken),
+						ghttp.VerifyJSON(`{
+							"enabled": true,
+							"guest_allow": "none",
+							"server_type": "macbook",
+							"login_name": "afpuser",
+							"login_password": "afppass"
+						}`),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": {
+								"enabled": true,
+								"guest_allow": "none",
+								"server_type": "macbook",
+								"login_name": "afpuser"
+							}
+						}`),
+					),
+				)
+			})
+			It("should return the updated AFP configuration", func() {
+				Expect(*returnedErr).To(BeNil())
+				Expect(*returnedConfig).To(MatchFields(IgnoreExtras, Fields{
+					"Enabled":    BeTrue(),
+					"GuestAllow": Equal("none"),
+					"ServerType": Equal(types.NetshareAFPServerTypeMacBook),
+					"LoginName":  Equal("afpuser"),
+				}))
+			})
+		})
+		Context("when the server fails to respond", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an api error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/netshare/afp/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": false,
+							"error_code": "invalid_afp_login_name",
+							"msg": "Invalid AFP user name"
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+		Context("when the server returns an unexpected payload", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPut, fmt.Sprintf("/api/%s/netshare/afp/", version)),
+						verifyAuth(*sessionToken),
+						ghttp.RespondWith(http.StatusOK, `{
+							"success": true,
+							"result": []
+						}`),
+					),
+				)
+			})
+			It("should return an error", func() {
+				Expect(*returnedErr).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/types/netshare.go
+++ b/types/netshare.go
@@ -1,0 +1,53 @@
+package types
+
+type SambaConfiguration struct {
+	FileShareEnabled  bool   `json:"file_share_enabled"`  // is file sharing enabled
+	PrintShareEnabled bool   `json:"print_share_enabled"` // is printer sharing enabled
+	LogonEnabled      bool   `json:"logon_enabled"`       // is login/password required to access shares
+	LogonUser         string `json:"logon_user"`          // login user name
+	Workgroup         string `json:"workgroup"`           // workgroup name
+	V2Enabled         bool   `json:"smbv2_enabled"`       // Set to true to enable SMBv2/v3
+}
+
+type SambaConfigurationPayload struct {
+	SambaConfiguration `json:",inline"`
+	LoginPassword      string `json:"login_password"` // Samba user password
+}
+
+type AFPConfiguration struct {
+	Enabled    bool                  `json:"enabled"`     // is afp service enabled
+	GuestAllow string                `json:"guest_allow"` // allow guest to access shared files
+	ServerType netshareAFPServerType `json:"server_type"` // Afp server type (to display proper icon) in MacOS
+	LoginName  string                `json:"login_name"`  // Afp user name
+}
+
+type AFPConfigurationPayload struct {
+	AFPConfiguration `json:",inline"`
+	LoginPassword    string `json:"login_password"` // Afp user password
+}
+
+type netshareAFPServerType = string
+
+const (
+	NetshareAFPServerTypePowerBook  netshareAFPServerType = "powerbook"
+	NetshareAFPServerTypePowerMac   netshareAFPServerType = "powermac"
+	NetshareAFPServerTypeMacMini    netshareAFPServerType = "macmini"
+	NetshareAFPServerTypeIMac       netshareAFPServerType = "imac"
+	NetshareAFPServerTypeMacBook    netshareAFPServerType = "macbook"
+	NetshareAFPServerTypeMacBookPro netshareAFPServerType = "macbookpro"
+	NetshareAFPServerTypeMacBookAir netshareAFPServerType = "macbookair"
+	NetshareAFPServerTypeMacPro     netshareAFPServerType = "macpro"
+	NetshareAFPServerTypeAppleTV    netshareAFPServerType = "appletv"
+	NetshareAFPServerTypeAirport    netshareAFPServerType = "airport"
+	NetshareAFPServerTypeXServe     netshareAFPServerType = "xserve"
+)
+
+type netshareError string
+
+const (
+	NetshareErrorInvalidWorkgroupName    netshareError = "invalid_workgroup_name"     // Invalid workgroup name
+	NetshareErrorInvalidLogonUser        netshareError = "invalid_logon_user"         // Invalid samba user name
+	NetshareErrorInvalidLogonPassword    netshareError = "invalid_logon_password"     // Invalid samba user password
+	NetshareErrorInvalidAFPLoginName     netshareError = "invalid_afp_login_name"     // Invalid AFP user name
+	NetshareErrorInvalidAFPLoginPassword netshareError = "invalid_afp_login_password" // Invalid AFP user password
+)

--- a/types/netshare.go
+++ b/types/netshare.go
@@ -10,8 +10,8 @@ type SambaConfiguration struct {
 }
 
 type SambaConfigurationPayload struct {
-	SambaConfiguration `json:",inline"`
-	LoginPassword      string `json:"login_password"` // Samba user password
+	SambaConfiguration
+	LoginPassword string `json:"login_password"` // Samba user password
 }
 
 type AFPConfiguration struct {
@@ -22,8 +22,8 @@ type AFPConfiguration struct {
 }
 
 type AFPConfigurationPayload struct {
-	AFPConfiguration `json:",inline"`
-	LoginPassword    string `json:"login_password"` // Afp user password
+	AFPConfiguration
+	LoginPassword string `json:"login_password"` // Afp user password
 }
 
 type netshareAFPServerType = string


### PR DESCRIPTION
## Summary
- Implements GET/PUT for Samba (`netshare/samba/`) and AFP (`netshare/afp/`) configuration
- Adds `SambaConfiguration`, `AFPConfiguration`, their payloads, AFP server type constants, and netshare-specific error codes
- Adds all four methods to the `Client` interface and updates README

## Test plan
- [x] `GetSambaConfiguration` / `UpdateSambaConfiguration`: success, server error, unexpected payload
- [x] `GetAFPConfiguration` / `UpdateAFPConfiguration`: success, server error, unexpected payload
- [x] Request body verified for both PUT operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)