### PR TITLE
feat(types): add error codes for access denied, rate limited, and invalid request

### DIFF
--- a/client/constants.go
+++ b/client/constants.go
@@ -23,6 +23,7 @@ const (
 	ErrTaskNotFound               = Error("task not found")
 	ErrDestinationConflict        = Error("file or folder already exists")
 	ErrVPNUserNotFound            = Error("vpn user not found")
+	ErrAccessDenied               = Error("access denied")
 )
 
 var (

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -26,8 +26,8 @@ func TestClient(t *testing.T) {
 }
 
 var _ = BeforeEach(func() {
-	DeferCleanup(func(existing []gleak.Goroutine) {
-		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(existing))
+	DeferCleanup(func(ctx SpecContext, existing []gleak.Goroutine) {
+		Eventually(gleak.Goroutines).WithContext(ctx).ShouldNot(gleak.HaveLeaked(existing))
 	}, gleak.Goroutines())
 })
 

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -26,9 +25,9 @@ func TestClient(t *testing.T) {
 	RunSpecs(t, "client")
 }
 
-var _ = BeforeEach(func(ctx context.Context) {
+var _ = BeforeEach(func() {
 	DeferCleanup(func(existing []gleak.Goroutine) {
-		Eventually(gleak.Goroutines).WithContext(ctx).ShouldNot(gleak.HaveLeaked(existing))
+		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(existing))
 	}, gleak.Goroutines())
 })
 

--- a/types/authorization.go
+++ b/types/authorization.go
@@ -11,7 +11,8 @@ type AuthorizationRequest struct {
 type ErrorCode string
 
 const (
-	AuthorizationErrorCode ErrorCode = "auth_required" // "Vous devez vous connecter pour accéder à cette fonction"
-	AccessDeniedErrorCode  ErrorCode = "access_denied" // "Accès refusé"
-	RateLimitedErrorCode   ErrorCode = "ratelimited"   // "Trop d'échec de connexion depuis cette ip"
+	AuthorizationErrorCode  ErrorCode = "auth_required"   // "Vous devez vous connecter pour accéder à cette fonction"
+	AccessDeniedErrorCode   ErrorCode = "access_denied"   // "Accès refusé"
+	RateLimitedErrorCode    ErrorCode = "ratelimited"     // "Trop d'échec de connexion depuis cette ip"
+	InvalidRequestErrorCode ErrorCode = "invalid_request" // e.g. invalid CSRF token
 )

--- a/types/authorization.go
+++ b/types/authorization.go
@@ -12,4 +12,6 @@ type ErrorCode string
 
 const (
 	AuthorizationErrorCode ErrorCode = "auth_required" // "Vous devez vous connecter pour accéder à cette fonction"
+	AccessDeniedErrorCode  ErrorCode = "access_denied" // "Accès refusé"
+	RateLimitedErrorCode   ErrorCode = "ratelimited"   // "Trop d'échec de connexion depuis cette ip"
 )

--- a/types/common.go
+++ b/types/common.go
@@ -51,6 +51,3 @@ func (c *Base64Path) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-const (
-	InvalidRequestErrorCode ErrorCode = "invalid_request" // e.g. invalid CSRF token
-)

--- a/types/common.go
+++ b/types/common.go
@@ -50,3 +50,7 @@ func (c *Base64Path) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+const (
+	InvalidRequestErrorCode ErrorCode = "invalid_request" // e.g. invalid CSRF token
+)


### PR DESCRIPTION
## Summary
- `types.AccessDeniedErrorCode` (`access_denied`) and `types.RateLimitedErrorCode` (`ratelimited`) added to `authorization.go`
- `types.InvalidRequestErrorCode` (`invalid_request`) added to `common.go` — surfaces when e.g. CSRF token validation fails
- `client.ErrAccessDenied` sentinel error added to `constants.go`

## Test plan
- [x] Build and full test suite pass (constants only, no logic to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)