### PR TITLE
docs: add Home and Camera planned endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,39 @@ At the time of this writing, generating credentials can only be done via the Fre
   - [x] Update a VPN client
   - [x] Delete a VPN client
   - [x] Create a VPN client
+- [ ] [Home](http://mafreebox.freebox.fr/#Fbx.os.app.help.app) (UNSTABLE) : `/home/*`
+  - [ ] List all home nodes
+  - [ ] Get a home node
+  - [ ] Update a home node
+  - [ ] Delete a home node
+  - [ ] List home adapters
+  - [ ] Get a home adapter
+  - [ ] Delete a home adapter
+  - [ ] Get an endpoint value
+  - [ ] Set an endpoint value
+  - [ ] Bulk-get endpoint values
+  - [ ] List home links
+  - [ ] Get a home link
+  - [ ] Delete a home link
+  - [ ] List available rules for a node
+  - [ ] Get a rule template configuration
+  - [ ] Get an existing rule configuration
+  - [ ] Create a rule from a template
+  - [ ] Update a rule
+  - [ ] Get the security module (alarm)
+  - [ ] List SMS numbers
+  - [ ] Create an SMS number
+  - [ ] Update an SMS number
+  - [ ] Send validation SMS
+  - [ ] Validate an SMS number
+  - [ ] List home tilesets
+  - [ ] Get a home tile
+  - [ ] Get pairing state
+  - [ ] Start/advance/stop pairing
+- [ ] [Camera](http://mafreebox.freebox.fr/#Fbx.os.app.help.app) (UNSTABLE) : `/camera/*`
+  - [ ] Get camera info and stream URLs
+  - [ ] Get a camera snapshot
+  - [ ] Get a camera stream (M3U8)
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Adds the **Home** API section (`/home/*`) to the planned endpoints list — covers nodes, adapters, endpoints (read/write), links, automation rules, alarm/security module, SMS alert numbers, tilesets, and device pairing
- Adds the **Camera** API section (`/camera/*`) — covers camera info, snapshots, and M3U8 streams
- Both are marked `(UNSTABLE)` and linked to the local Freebox OS help (they are absent from the public developer documentation at dev.freebox.fr)
- No code changes; README only

## References

The Home and Camera APIs were sourced from:
- Local Freebox OS documentation at `http://mafreebox.freebox.fr/#Fbx.os.app.help.app`
- [`hacf-fr/freebox-api`](https://github.com/hacf-fr/freebox-api) Python SDK (`freebox_api/api/home.py`)
- Community integrations (Homebridge, Home Assistant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)